### PR TITLE
🎞️ Double buffering

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,8 +48,8 @@ superluminal-perf = { version = "0.3.0", default-features = false }
 tinybvh = { git = "https://github.com/TemporalInteractive/tinybvh.git", rev = "889dadf", default-features = false, features = ["simd", "unsafe-send-sync"] }
 # tinybvh = { path = "../tinybvh", default-features = false, features = ["simd", "unsafe-send-sync"] }
 turbojpeg = { version = "1.2.1", default-features = true }
-# unreliable = { git = "https://github.com/TemporalInteractive/unreliable.git", rev = "85dff33", default-features = false }
-unreliable = { path = "../unreliable/unreliable", default-features = false }
+unreliable = { git = "https://github.com/TemporalInteractive/unreliable.git", rev = "b44e153", default-features = false }
+# unreliable = { path = "../unreliable/unreliable", default-features = false }
 uuid = { version = "1.12.1", default-features = false, features = ["std", "v4", "bytemuck"]}
 winit = { version = "0.30.5", default-features = false, features = ["rwh_06"] }
 wgpu = { version = "23.0.1", default-features = false, features = ["wgsl"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,8 +48,8 @@ superluminal-perf = { version = "0.3.0", default-features = false }
 tinybvh = { git = "https://github.com/TemporalInteractive/tinybvh.git", rev = "889dadf", default-features = false, features = ["simd", "unsafe-send-sync"] }
 # tinybvh = { path = "../tinybvh", default-features = false, features = ["simd", "unsafe-send-sync"] }
 turbojpeg = { version = "1.2.1", default-features = true }
-unreliable = { git = "https://github.com/TemporalInteractive/unreliable.git", rev = "85dff33", default-features = false }
-# unreliable = { path = "../unreliable/unreliable", default-features = false }
+# unreliable = { git = "https://github.com/TemporalInteractive/unreliable.git", rev = "85dff33", default-features = false }
+unreliable = { path = "../unreliable/unreliable", default-features = false }
 uuid = { version = "1.12.1", default-features = false, features = ["std", "v4", "bytemuck"]}
 winit = { version = "0.30.5", default-features = false, features = ["rwh_06"] }
 wgpu = { version = "23.0.1", default-features = false, features = ["wgsl"] }

--- a/crates/appearance-path-tracer/src/lib.rs
+++ b/crates/appearance-path-tracer/src/lib.rs
@@ -98,7 +98,7 @@ impl PathTracer {
 
         self.geometry_resources.rebuild_tlas();
 
-        let samples_per_pixel = 2;
+        let samples_per_pixel = 1;
 
         // Loop over the number of blocks, flattened to allow for better multithreading utilization
         let flat_block_indices = (0..(num_blocks_y * num_blocks_x)).collect::<Vec<u32>>();

--- a/crates/appearance-path-tracer/src/path_integrator.rs
+++ b/crates/appearance-path-tracer/src/path_integrator.rs
@@ -44,13 +44,13 @@ impl PathIntegrator {
                 break;
             }
 
-            let normal_f = RgbAlbedoSpectrum::new(
-                Rgb(hit_data.normal * 0.5 + 0.5),
-                RgbColorSpace::srgb().as_ref(),
-            )
-            .sample(wavelengths);
-            l += normal_f.0;
-            break;
+            // let normal_f = RgbAlbedoSpectrum::new(
+            //     Rgb(hit_data.normal * 0.5 + 0.5),
+            //     RgbColorSpace::srgb().as_ref(),
+            // )
+            // .sample(wavelengths);
+            // l += normal_f.0;
+            // break;
 
             // TODO: triangle light radiance on hit
 

--- a/crates/appearance-path-tracer/src/path_integrator.rs
+++ b/crates/appearance-path-tracer/src/path_integrator.rs
@@ -44,13 +44,13 @@ impl PathIntegrator {
                 break;
             }
 
-            // let normal_f = RgbAlbedoSpectrum::new(
-            //     Rgb(hit_data.normal * 0.5 + 0.5),
-            //     RgbColorSpace::srgb().as_ref(),
-            // )
-            // .sample(wavelengths);
-            // l += normal_f.0;
-            // break;
+            let normal_f = RgbAlbedoSpectrum::new(
+                Rgb(hit_data.normal * 0.5 + 0.5),
+                RgbColorSpace::srgb().as_ref(),
+            )
+            .sample(wavelengths);
+            l += normal_f.0;
+            break;
 
             // TODO: triangle light radiance on hit
 

--- a/crates/appearance-path-tracer/src/path_tracer.rs
+++ b/crates/appearance-path-tracer/src/path_tracer.rs
@@ -24,6 +24,7 @@ pub struct SamplePixelResult {
     pub sampled_wavelengths: SampledWavelengths,
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn render_pixels(
     uv: [Vec2; RAYS_PER_PACKET],
     seed: u64,

--- a/crates/appearance-render-loop/src/host.rs
+++ b/crates/appearance-render-loop/src/host.rs
@@ -172,10 +172,6 @@ impl BufferedPixelData {
         }
     }
 
-    fn write_pixels_idx(&self) -> usize {
-        self.frame_idx.load(Ordering::SeqCst) as usize % BUFFERED_PIXEL_COUNT
-    }
-
     fn read_pixels_idx(&self) -> usize {
         (self.frame_idx.load(Ordering::SeqCst) + 1) as usize % BUFFERED_PIXEL_COUNT
     }

--- a/crates/appearance-render-loop/src/host.rs
+++ b/crates/appearance-render-loop/src/host.rs
@@ -9,7 +9,6 @@ use std::{
     collections::HashMap,
     sync::{Arc, Mutex},
     thread,
-    time::Duration,
 };
 
 use unreliable::{Socket, SocketEvent};
@@ -274,14 +273,12 @@ impl Host {
         let recieve_events_connected_nodes = connected_nodes.clone();
         let recieve_events_has_received_new_connections = has_received_new_connections.clone();
         let recieve_events_pixels = pixels.clone();
-        let recieve_events_width = width;
         thread::spawn(move || {
             Self::receive_events(
                 receive_events_event_receiver,
                 recieve_events_connected_nodes,
                 recieve_events_has_received_new_connections,
                 recieve_events_pixels,
-                recieve_events_width,
             )
         });
 
@@ -303,7 +300,6 @@ impl Host {
         connected_nodes: Arc<Mutex<Vec<SocketAddr>>>,
         has_received_new_connections: Arc<AtomicBool>,
         pixels: Arc<BufferedPixelData>,
-        width: u32,
     ) {
         loop {
             if let Ok(socket_event) = event_receiver.recv() {

--- a/crates/appearance-render-loop/src/node.rs
+++ b/crates/appearance-render-loop/src/node.rs
@@ -77,6 +77,7 @@ impl<T: NodeRenderer + 'static> Node<T> {
                             NodeToHostMessage::RenderPartialFinished(RenderPartialFinishedData {
                                 row: (local_block_y * RENDER_BLOCK_SIZE) + data.row_start,
                                 column_block: local_block_x,
+                                frame_idx: data.frame_idx,
                                 compressed_pixel_bytes: compressed_pixel_bytes.to_vec(),
                             });
 
@@ -103,7 +104,11 @@ impl<T: NodeRenderer + 'static> Node<T> {
             #[allow(clippy::collapsible_match)]
             if let Ok(socket_event) = self.socket.event_receiver().try_recv() {
                 match socket_event {
-                    SocketEvent::Packet(packet) => {
+                    SocketEvent::Packet(packet, delay) => {
+                        if delay > 0 {
+                            continue;
+                        }
+
                         if let Ok(message) = HostToNodeMessage::from_bytes(packet.payload()) {
                             match message {
                                 HostToNodeMessage::StartRender(data) => {


### PR DESCRIPTION
This PR introduces double buffering for the pixel data on the receiving host. This gives pixel packets more time to arrive on the host before they are seen as "too late" and discarded. This massively reduces screen tearing.