### PR TITLE
💦 GBuffer

### DIFF
--- a/crates/appearance-path-tracer-gpu/assets/shaders/apply_di.wgsl
+++ b/crates/appearance-path-tracer-gpu/assets/shaders/apply_di.wgsl
@@ -83,10 +83,9 @@ fn main(@builtin(global_invocation_id) global_id: vec3<u32>,
 
     let shadow_direction: vec3<f32> = normalize(light_sample.point - hit_point_ws);
     let shadow_distance: f32 = distance(light_sample.point, hit_point_ws);
-    let shadow_origin: vec3<f32> = hit_point_ws + shadow_direction * 0.0001;
     let n_dot_l: f32 = dot(shadow_direction, front_facing_shading_normal_ws);
     if (n_dot_l > 0.0) {
-        if (trace_shadow_ray(shadow_origin, shadow_direction, shadow_distance, scene)) {
+        if (trace_shadow_ray(hit_point_ws, shadow_direction, shadow_distance, scene)) {
             let w_out_worldspace: vec3<f32> = -direction;
             let w_in_worldspace: vec3<f32> = shadow_direction;
 

--- a/crates/appearance-path-tracer-gpu/assets/shaders/shared/gbuffer.wgsl
+++ b/crates/appearance-path-tracer-gpu/assets/shaders/shared/gbuffer.wgsl
@@ -1,0 +1,22 @@
+@include ::packing
+
+struct GBufferTexel {
+    depth_ws: f32,
+    normal_ws: PackedNormalizedXyz10,
+    _padding0: u32,
+    _padding1: u32,
+}
+
+fn GBufferTexel::new(depth_ws: f32, normal_ws: vec3<f32>) -> GBufferTexel {
+    return GBufferTexel(
+        depth_ws,
+        PackedNormalizedXyz10::new(normal_ws, 0),
+        0,
+        0
+    );
+}
+
+fn GBufferTexel::depth_cs(_self: GBufferTexel, z_near: f32, z_far: f32) -> f32 {
+    let z_linear: f32 = (_self.depth_ws - z_near) / z_far;
+    return (z_near * z_far) / (z_far - z_linear * (z_far - z_near));
+}

--- a/crates/appearance-path-tracer-gpu/assets/shaders/shared/material/disney_bsdf.wgsl
+++ b/crates/appearance-path-tracer-gpu/assets/shaders/shared/material/disney_bsdf.wgsl
@@ -463,7 +463,12 @@ fn DisneyBsdf::sample(_self: DisneyBsdf, i_n: vec3<f32>,
         mix(_self.specular, 1.0, _self.metallic),
         _self.clearcoat * 0.25
     );
-    weights *= 1.0 / (weights.x + weights.y + weights.z + weights.w);
+    let weights_sum: f32 = weights.x + weights.y + weights.z + weights.w;
+    if (weights_sum == 0.0) {
+        *pdf = 0.0;
+        return vec3<f32>(0.0);
+    }
+    weights *= 1.0 / weights_sum;
     let cdf = vec4<f32>(
         weights.x,
         weights.x + weights.y,
@@ -618,7 +623,12 @@ fn DisneyBsdf::evaluate(_self: DisneyBsdf, i_n: vec3<f32>,
         mix(_self.specular, 1.0, _self.metallic),
         _self.clearcoat * 0.25
     );
-    weights *= 1.0 / (weights.x + weights.y + weights.z + weights.w);
+    let weights_sum: f32 = weights.x + weights.y + weights.z + weights.w;
+    if (weights_sum == 0.0) {
+        *pdf = 0.0;
+        return vec3<f32>(0.0);
+    }
+    weights *= 1.0 / weights_sum;
 
     *pdf = 0.0;
     var value = vec3<f32>(0.0);

--- a/crates/appearance-path-tracer-gpu/assets/shaders/shared/material/material_pool_bindings.wgsl
+++ b/crates/appearance-path-tracer-gpu/assets/shaders/shared/material/material_pool_bindings.wgsl
@@ -125,9 +125,8 @@ fn MaterialDescriptor::apply_clearcoat_normal_mapping(_self: MaterialDescriptor,
     return normal_ws;
 }
 
-fn Material::from_material_descriptor(material_descriptor: MaterialDescriptor, tex_coord: vec2<f32>) -> Material {
+fn Material::from_material_descriptor_with_color(material_descriptor: MaterialDescriptor, tex_coord: vec2<f32>, color: vec4<f32>) -> Material {
     var material: Material;
-    let color: vec4<f32> = MaterialDescriptor::color(material_descriptor, tex_coord);
     material.color = color.rgb;
     material.luminance = color.a;
     let metallic_roughness = MaterialDescriptor::metallic_roughness(material_descriptor, tex_coord);
@@ -147,4 +146,9 @@ fn Material::from_material_descriptor(material_descriptor: MaterialDescriptor, t
     material.clearcoat_roughness = MaterialDescriptor::clearcoat_roughness(material_descriptor, tex_coord);
     material.alpha_cutoff = material_descriptor.alpha_cutoff;
     return material;
+}
+
+fn Material::from_material_descriptor(material_descriptor: MaterialDescriptor, tex_coord: vec2<f32>) -> Material {
+    let color: vec4<f32> = MaterialDescriptor::color(material_descriptor, tex_coord);
+    return Material::from_material_descriptor_with_color(material_descriptor, tex_coord, color);
 }

--- a/crates/appearance-path-tracer-gpu/assets/shaders/shared/trace_helpers.wgsl
+++ b/crates/appearance-path-tracer-gpu/assets/shaders/shared/trace_helpers.wgsl
@@ -4,7 +4,7 @@
 /// appearance-path-tracer-gpu::shared/material/material_pool_bindings
 ///
 
-const MAX_NON_OPAQUE_DEPTH: u32 = 1;
+const MAX_NON_OPAQUE_DEPTH: u32 = 3;
 
 fn trace_shadow_ray_opaque(origin: vec3<f32>, direction: vec3<f32>, distance: f32, scene: acceleration_structure) -> bool {
     var shadow_rq: ray_query;

--- a/crates/appearance-path-tracer-gpu/assets/shaders/trace.wgsl
+++ b/crates/appearance-path-tracer-gpu/assets/shaders/trace.wgsl
@@ -184,6 +184,17 @@ fn main(@builtin(global_invocation_id) global_id: vec3<u32>,
             light_sample_reservoirs[id] = PackedDiReservoir::new(di_reservoir);
             light_sample_ctxs[id] = LightSampleCtx::new(tex_coord, material_idx, throughput, front_facing_shading_normal_ws, clearcoat_tangent_to_world[2]);
 
+            if (constants.bounce > 1) {
+                let russian_roulette: f32 = max(throughput.r, max(throughput.g, throughput.b));
+
+                if (russian_roulette < random_uniform_float(&rng)) {
+                    payload.t = -1.0;
+                    break;
+                } else {
+                    throughput *= 1.0 / russian_roulette;
+                }
+            }
+
             var w_in_worldspace: vec3<f32>;
             var pdf: f32;
             var specular: bool;

--- a/crates/appearance-path-tracer-gpu/assets/shaders/trace.wgsl
+++ b/crates/appearance-path-tracer-gpu/assets/shaders/trace.wgsl
@@ -38,7 +38,6 @@ var scene: acceleration_structure;
 
 @group(0)
 @binding(5)
-//var<storage, read_write> light_samples: array<PackedLightSample>;
 var<storage, read_write> light_sample_reservoirs: array<PackedDiReservoir>;
 
 @group(0)

--- a/crates/appearance-path-tracer-gpu/src/scene_resources/sky.rs
+++ b/crates/appearance-path-tracer-gpu/src/scene_resources/sky.rs
@@ -35,7 +35,7 @@ impl Default for SunInfo {
             direction: Vec3::new(-0.2, -1.0, 0.1).normalize(),
             color: Vec3::new(1.0, 1.0, 1.0),
             size: 0.5,
-            intensity: 5.0, //50.0,
+            intensity: 50.0,
         }
     }
 }

--- a/crates/appearance-path-tracer-gpu/src/trace_pass.rs
+++ b/crates/appearance-path-tracer-gpu/src/trace_pass.rs
@@ -27,6 +27,7 @@ pub struct TracePassParameters<'a> {
     pub payloads: &'a wgpu::Buffer,
     pub light_sample_reservoirs: &'a wgpu::Buffer,
     pub light_sample_ctxs: &'a wgpu::Buffer,
+    pub gbuffer: &'a wgpu::Buffer,
     pub scene_resources: &'a SceneResources,
 }
 
@@ -119,6 +120,16 @@ pub fn encode(
                                 },
                                 count: None,
                             },
+                            wgpu::BindGroupLayoutEntry {
+                                binding: 7,
+                                visibility: wgpu::ShaderStages::COMPUTE,
+                                ty: wgpu::BindingType::Buffer {
+                                    ty: wgpu::BufferBindingType::Storage { read_only: false },
+                                    has_dynamic_offset: false,
+                                    min_binding_size: None,
+                                },
+                                count: None,
+                            },
                         ],
                     }),
                     parameters.scene_resources.vertex_pool().bind_group_layout(),
@@ -178,6 +189,10 @@ pub fn encode(
             wgpu::BindGroupEntry {
                 binding: 6,
                 resource: parameters.light_sample_ctxs.as_entire_binding(),
+            },
+            wgpu::BindGroupEntry {
+                binding: 7,
+                resource: parameters.gbuffer.as_entire_binding(),
             },
         ],
     });


### PR DESCRIPTION
This PR adds a basic GBuffer with history. It stores the depth in world space, as well as the front facing shading normal in world space. It is currently only used for restir di, where it acts as a rejection method to supress bias.

Without GBuffer rejection:
![Screenshot 2025-03-09 201725](https://github.com/user-attachments/assets/11c1bb86-7fbb-400e-aca8-b5257528de33)

With GBuffer rejection:
![Screenshot 2025-03-09 201649](https://github.com/user-attachments/assets/48835461-0eb1-4b34-8b11-713edb6c590f)
