### PR TITLE
✅ Optional GPU validation

### DIFF
--- a/apps/render-host/src/lib.rs
+++ b/apps/render-host/src/lib.rs
@@ -45,6 +45,10 @@ struct Args {
     /// Run the renderer inside the host as a traditional engine would
     #[arg(long, default_value_t = true)]
     render_local: bool,
+
+    /// Forcefully disable gpu validation
+    #[arg(long, default_value_t = false)]
+    no_gpu_validation: bool,
 }
 
 pub struct HostRenderLoop {
@@ -405,6 +409,7 @@ pub fn internal_main() -> Result<()> {
         height: 640,
         resizeable: true,
         maximized: false,
+        no_gpu_validation: Args::parse().no_gpu_validation,
     })
     .run()?;
 

--- a/apps/render-node/src/lib.rs
+++ b/apps/render-node/src/lib.rs
@@ -21,6 +21,10 @@ struct Args {
     /// Node port to receive events
     #[arg(long, default_value_t = 34235)]
     node_port: u16,
+
+    /// Forcefully disable gpu validation
+    #[arg(long, default_value_t = false)]
+    no_gpu_validation: bool,
 }
 
 pub fn internal_main() -> Result<()> {
@@ -29,7 +33,11 @@ pub fn internal_main() -> Result<()> {
     let args = Args::parse();
     let addr = SocketAddr::from_str(&format!("{}:{}", args.host_ip, args.host_port)).unwrap();
 
-    let node = Node::new(DistributedRenderer::new(), addr, args.node_port)?;
+    let node = Node::new(
+        DistributedRenderer::new(args.no_gpu_validation),
+        addr,
+        args.node_port,
+    )?;
     node.run();
 
     Ok(())

--- a/crates/appearance-distributed-renderer/src/lib.rs
+++ b/crates/appearance-distributed-renderer/src/lib.rs
@@ -14,14 +14,8 @@ pub struct DistributedRenderer {
     path_tracer: PathTracerGpu,
 }
 
-impl Default for DistributedRenderer {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 impl DistributedRenderer {
-    pub fn new() -> Self {
+    pub fn new(no_gpu_validation: bool) -> Self {
         let ctx = Arc::new(block_on(Context::init(
             wgpu::Features::empty(),
             wgpu::Features::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES
@@ -44,6 +38,7 @@ impl DistributedRenderer {
                 max_binding_array_elements_per_shader_stage: 1024 * 32,
                 ..wgpu::Limits::default()
             },
+            no_gpu_validation,
         )));
 
         Self::new_with_context(ctx)

--- a/crates/appearance-render-loop/src/lib.rs
+++ b/crates/appearance-render-loop/src/lib.rs
@@ -58,7 +58,11 @@ struct RenderLoopState<R: RenderLoop> {
 }
 
 impl<R: RenderLoop> RenderLoopState<R> {
-    pub async fn from_window(mut surface: Surface, window: Arc<Window>) -> Self {
+    pub async fn from_window(
+        mut surface: Surface,
+        window: Arc<Window>,
+        no_gpu_validation: bool,
+    ) -> Self {
         let context = Arc::new(
             Context::init_with_window(
                 &mut surface,
@@ -67,6 +71,7 @@ impl<R: RenderLoop> RenderLoopState<R> {
                 R::required_features(),
                 R::required_downlevel_capabilities(),
                 R::required_limits(),
+                no_gpu_validation,
             )
             .await,
         );
@@ -91,6 +96,7 @@ pub struct RenderLoopWindowDesc {
     pub height: u32,
     pub resizeable: bool,
     pub maximized: bool,
+    pub no_gpu_validation: bool,
 }
 
 impl Default for RenderLoopWindowDesc {
@@ -101,6 +107,7 @@ impl Default for RenderLoopWindowDesc {
             height: 1080,
             resizeable: true,
             maximized: false,
+            no_gpu_validation: false,
         }
     }
 }
@@ -145,7 +152,11 @@ impl<R: RenderLoop> ApplicationHandler for RenderLoopHandler<R> {
             .with_maximized(self.window_desc.maximized);
         let window = Arc::new(event_loop.create_window(window_attributes).unwrap());
 
-        self.state = Some(block_on(RenderLoopState::<R>::from_window(surface, window)));
+        self.state = Some(block_on(RenderLoopState::<R>::from_window(
+            surface,
+            window,
+            self.window_desc.no_gpu_validation,
+        )));
     }
 
     fn suspended(&mut self, _event_loop: &ActiveEventLoop) {

--- a/crates/appearance-wgpu/src/lib.rs
+++ b/crates/appearance-wgpu/src/lib.rs
@@ -1,7 +1,6 @@
-use std::{future::IntoFuture, sync::Arc};
-
 use bytemuck::Pod;
 use futures::{channel::oneshot, executor::block_on};
+use std::{future::IntoFuture, sync::Arc};
 use wgpu::{DownlevelCapabilities, Features, Instance, Limits, PowerPreference};
 use winit::{
     dpi::PhysicalSize,
@@ -222,12 +221,18 @@ impl Context {
         required_features: Features,
         required_downlevel_capabilities: DownlevelCapabilities,
         required_limits: Limits,
+        no_gpu_validation: bool,
     ) -> Self {
         log::info!("Initializing wgpu...");
 
+        let mut flags = wgpu::InstanceFlags::DEBUG;
+        if no_gpu_validation {
+            flags |= wgpu::InstanceFlags::VALIDATION;
+        }
+
         let instance = wgpu::Instance::new(&wgpu::InstanceDescriptor {
             backends: wgpu::Backends::VULKAN,
-            flags: wgpu::InstanceFlags::DEBUG | wgpu::InstanceFlags::VALIDATION,
+            flags,
             backend_options: wgpu::BackendOptions::default(),
         });
         surface.pre_adapter(&instance, window);
@@ -247,12 +252,18 @@ impl Context {
         required_features: Features,
         required_downlevel_capabilities: DownlevelCapabilities,
         required_limits: Limits,
+        no_gpu_validation: bool,
     ) -> Self {
         log::info!("Initializing wgpu...");
 
+        let mut flags = wgpu::InstanceFlags::DEBUG;
+        if no_gpu_validation {
+            flags |= wgpu::InstanceFlags::VALIDATION;
+        }
+
         let instance = wgpu::Instance::new(&wgpu::InstanceDescriptor {
             backends: wgpu::Backends::VULKAN,
-            flags: wgpu::InstanceFlags::DEBUG | wgpu::InstanceFlags::VALIDATION,
+            flags,
             backend_options: wgpu::BackendOptions::default(),
         });
 


### PR DESCRIPTION
This PR allows disabling gpu validation from the command line. Just pass `--no-gpu-validation` as an extra arg to disable any validation layers. This is useful for gpu debugging as nsight requires validation layers to be disabled when profiling / tracing. Changing this manually in code each time is very cumbersome.