### PR TITLE
⚖️ Unbiased restir

### DIFF
--- a/crates/appearance-path-tracer-gpu/src/lib.rs
+++ b/crates/appearance-path-tracer-gpu/src/lib.rs
@@ -294,6 +294,7 @@ impl PathTracerGpu {
                             seed: self.frame_idx,
                             spatial_pass_count: 2,
                             spatial_pixel_radius: 30.0,
+                            unbiased: false,
                             in_rays,
                             payloads: &self.sized_resources.payloads,
                             light_sample_reservoirs: &self.sized_resources.light_sample_reservoirs,

--- a/crates/appearance-path-tracer-gpu/src/restir_di_pass.rs
+++ b/crates/appearance-path-tracer-gpu/src/restir_di_pass.rs
@@ -15,6 +15,10 @@ struct TemporalConstants {
     resolution: UVec2,
     ray_count: u32,
     spatial_pass_count: u32,
+    unbiased: u32,
+    _padding0: u32,
+    _padding1: u32,
+    _padding2: u32,
 }
 
 #[derive(Pod, Clone, Copy, Zeroable)]
@@ -26,7 +30,7 @@ struct SpatialConstants {
     pixel_radius: f32,
     seed: u32,
     spatial_idx: u32,
-    _padding0: u32,
+    unbiased: u32,
 }
 
 #[repr(C)]
@@ -62,6 +66,7 @@ pub struct RestirDiPassParameters<'a> {
     pub seed: u32,
     pub spatial_pass_count: u32,
     pub spatial_pixel_radius: f32,
+    pub unbiased: bool,
     pub in_rays: &'a wgpu::Buffer,
     pub payloads: &'a wgpu::Buffer,
     pub light_sample_reservoirs: &'a wgpu::Buffer,
@@ -224,6 +229,10 @@ impl RestirDiPass {
                 resolution: parameters.resolution,
                 ray_count,
                 spatial_pass_count: parameters.spatial_pass_count,
+                unbiased: parameters.unbiased as u32,
+                _padding0: 0,
+                _padding1: 0,
+                _padding2: 0,
             }),
             usage: wgpu::BufferUsages::UNIFORM,
         });
@@ -417,7 +426,7 @@ impl RestirDiPass {
                     pixel_radius: parameters.spatial_pixel_radius,
                     seed: parameters.seed,
                     spatial_idx: i,
-                    _padding0: 0,
+                    unbiased: parameters.unbiased as u32,
                 }),
                 usage: wgpu::BufferUsages::UNIFORM,
             });


### PR DESCRIPTION
This PR introduces an unbiased form of restir for direct illumination. The current biased form looks better with a low sample count, but introduces minor artifacts. When increasing the sample count this becomes only more prominent, making an unbiased form more desirable.

With 8 samples per pixel.

Biased:
![Screenshot 2025-03-13 110526](https://github.com/user-attachments/assets/01aec150-f637-4fa1-bdf2-116bb5b14093)

Unbiased:
![Screenshot 2025-03-13 110602](https://github.com/user-attachments/assets/a161f169-0727-427a-85bd-a7bf0818a487)
