### PR TITLE
🏎️ TAA reprojection

### DIFF
--- a/crates/appearance-path-tracer-gpu/src/lib.rs
+++ b/crates/appearance-path-tracer-gpu/src/lib.rs
@@ -210,7 +210,7 @@ impl Default for PathTracerGpuConfig {
             restir_di: true,
             restir_gi: true,
             firefly_filter: false,
-            taa: false,
+            taa: true,
         }
     }
 }
@@ -488,6 +488,7 @@ impl PathTracerGpu {
                     demodulated_radiance,
                     prev_demodulated_radiance,
                     gbuffer: &self.sized_resources.gbuffer,
+                    velocity_texture_view: &self.sized_resources.velocity_texture_view,
                 },
                 &ctx.device,
                 &mut command_encoder,

--- a/crates/appearance-path-tracer-gpu/src/taa_pass.rs
+++ b/crates/appearance-path-tracer-gpu/src/taa_pass.rs
@@ -23,6 +23,7 @@ pub struct TaaPassParameters<'a> {
     pub demodulated_radiance: &'a wgpu::Buffer,
     pub prev_demodulated_radiance: &'a wgpu::Buffer,
     pub gbuffer: &'a GBuffer,
+    pub velocity_texture_view: &'a wgpu::TextureView,
 }
 
 pub fn encode(
@@ -78,6 +79,16 @@ pub fn encode(
                                 },
                                 count: None,
                             },
+                            wgpu::BindGroupLayoutEntry {
+                                binding: 3,
+                                visibility: wgpu::ShaderStages::COMPUTE,
+                                ty: wgpu::BindingType::StorageTexture {
+                                    access: wgpu::StorageTextureAccess::ReadOnly,
+                                    format: wgpu::TextureFormat::Rgba32Float,
+                                    view_dimension: wgpu::TextureViewDimension::D2,
+                                },
+                                count: None,
+                            },
                         ],
                     }),
                     empty_bind_group_layout(device),
@@ -116,6 +127,10 @@ pub fn encode(
             wgpu::BindGroupEntry {
                 binding: 2,
                 resource: parameters.prev_demodulated_radiance.as_entire_binding(),
+            },
+            wgpu::BindGroupEntry {
+                binding: 3,
+                resource: wgpu::BindingResource::TextureView(parameters.velocity_texture_view),
             },
         ],
     });


### PR DESCRIPTION
This PR makes sure TAA makes use of the recently added rasterized velocity vectors.

No TAA:
![Screenshot 2025-03-17 092459](https://github.com/user-attachments/assets/7a175533-4996-4aad-9403-e8be9128ee4e)

With TAA:
![Screenshot 2025-03-17 092435](https://github.com/user-attachments/assets/5301d675-bbf8-4d51-ac2a-7684c323c993)
