### PR TITLE
🎯 Moving light tracking

### DIFF
--- a/apps/render-host/src/lib.rs
+++ b/apps/render-host/src/lib.rs
@@ -130,18 +130,18 @@ impl RenderLoop for HostRenderLoop {
         let _ = world.create_entity(
             "Sponza",
             Transform::new(Vec3::new(3.0, 0.0, 0.0), Quat::IDENTITY, Vec3::splat(1.0)),
-            |builder| builder.with(ModelComponent::new("::SponzaSheen.glb")),
+            |builder| builder.with(ModelComponent::new("::SponzaGlossy.glb")),
         );
         // let _ = world.create_entity(
         //     "CornellBox",
         //     Transform::new(Vec3::new(0.0, 0.0, 0.0), Quat::IDENTITY, Vec3::splat(1.0)),
         //     |builder| builder.with(ModelComponent::new("::CornellBoxConor.glb")),
         // );
-        // let _ = world.create_entity(
-        //     "Orbs",
-        //     Transform::new(Vec3::new(3.0, 0.0, 0.0), Quat::IDENTITY, Vec3::splat(1.0)),
-        //     |builder| builder.with(ModelComponent::new("::SponzaOrbs.glb")),
-        // );
+        let _ = world.create_entity(
+            "Orbs",
+            Transform::new(Vec3::new(3.0, 0.0, 0.0), Quat::IDENTITY, Vec3::splat(1.0)),
+            |builder| builder.with(ModelComponent::new("::SponzaOrbs.glb")),
+        );
         // let _ = world.create_entity(
         //     "NeonSigns",
         //     Transform::new(Vec3::new(3.0, 0.0, 0.0), Quat::IDENTITY, Vec3::splat(1.0)),

--- a/apps/render-host/src/lib.rs
+++ b/apps/render-host/src/lib.rs
@@ -63,7 +63,7 @@ pub struct HostRenderLoop {
     camera_controller: CameraController,
     world: World,
     // duck_entity: Option<specs::Entity>,
-    // toy_car_entity: specs::Entity,
+    toy_car_entity: specs::Entity,
 }
 
 impl RenderLoop for HostRenderLoop {
@@ -130,14 +130,14 @@ impl RenderLoop for HostRenderLoop {
         let _ = world.create_entity(
             "Sponza",
             Transform::new(Vec3::new(3.0, 0.0, 0.0), Quat::IDENTITY, Vec3::splat(1.0)),
-            |builder| builder.with(ModelComponent::new("::SponzaGlossy.glb")),
+            |builder| builder.with(ModelComponent::new("::Sponza.glb")),
         );
         // let _ = world.create_entity(
         //     "CornellBox",
         //     Transform::new(Vec3::new(0.0, 0.0, 0.0), Quat::IDENTITY, Vec3::splat(1.0)),
         //     |builder| builder.with(ModelComponent::new("::CornellBoxConor.glb")),
         // );
-        let _ = world.create_entity(
+        let toy_car_entity = world.create_entity(
             "Orbs",
             Transform::new(Vec3::new(3.0, 0.0, 0.0), Quat::IDENTITY, Vec3::splat(1.0)),
             |builder| builder.with(ModelComponent::new("::SponzaOrbs.glb")),
@@ -208,7 +208,7 @@ impl RenderLoop for HostRenderLoop {
             camera_controller: CameraController::new(),
             world,
             // duck_entity: Some(duck_entity),
-            // toy_car_entity,
+            toy_car_entity,
         }
     }
 
@@ -272,13 +272,13 @@ impl RenderLoop for HostRenderLoop {
         //     duck_transform.transform.translate(RIGHT * delta_time * 0.5);
         // }
 
-        // {
-        //     let mut transforms_mut = self.world.entities_mut::<TransformComponent>();
-        //     let transform = transforms_mut.get_mut(self.toy_car_entity).unwrap();
-        //     transform
-        //         .transform
-        //         .rotate(Quat::from_axis_angle(UP, delta_time * 0.3));
-        // }
+        {
+            let mut transforms_mut = self.world.entities_mut::<TransformComponent>();
+            let transform = transforms_mut.get_mut(self.toy_car_entity).unwrap();
+            transform
+                .transform
+                .rotate(Quat::from_axis_angle(UP, delta_time * 0.3));
+        }
 
         // if self.input_handler.key(KeyCode::KeyX) {
         //     if let Some(duck_entity) = self.duck_entity.take() {

--- a/apps/render-host/src/lib.rs
+++ b/apps/render-host/src/lib.rs
@@ -130,7 +130,7 @@ impl RenderLoop for HostRenderLoop {
         let _ = world.create_entity(
             "Sponza",
             Transform::new(Vec3::new(3.0, 0.0, 0.0), Quat::IDENTITY, Vec3::splat(1.0)),
-            |builder| builder.with(ModelComponent::new("::Sponza.glb")),
+            |builder| builder.with(ModelComponent::new("::SponzaGlossy.glb")),
         );
         // let _ = world.create_entity(
         //     "CornellBox",

--- a/assets/shaders/triangle.wgsl
+++ b/assets/shaders/triangle.wgsl
@@ -18,8 +18,9 @@ fn Triangle::area_from_edges(p01: vec3<f32>, p02: vec3<f32>) -> f32 {
     return length(cross(p01, p02)) * 0.5;
 }
 
-fn Triangle::solid_angle(cos_out: f32, area: f32, distance: f32) -> f32 {
-    return min(TWO_PI, (cos_out * area) / (sqr(distance) + 0.0001));
+fn Triangle::solid_angle(normal: vec3<f32>, direction: vec3<f32>, distance: f32) -> f32 {
+    let cos_out: f32 = max(-dot(normal, direction), 0.0);
+    return min(TWO_PI, cos_out / (sqr(distance) + 0.0001));
 }
 
 fn Triangle::transform(_self: Triangle, transform: mat4x4<f32>) -> Triangle {

--- a/crates/appearance-path-tracer-gpu/assets/shaders/apply_di.wgsl
+++ b/crates/appearance-path-tracer-gpu/assets/shaders/apply_di.wgsl
@@ -61,7 +61,7 @@ fn main(@builtin(global_invocation_id) global_id: vec3<u32>,
 
     let di_reservoir: DiReservoir = PackedDiReservoir::unpack(light_sample_reservoirs[id]);
     let light_sample: LightSample = di_reservoir.sample;
-    if (di_reservoir.contribution_weight == 0.0) { return; }
+    if (di_reservoir.contribution_weight == 0.0) { return; } //  || LightSample::is_empty(light_sample)
 
     let light_sample_ctx: LightSampleCtx = light_sample_ctxs[id];
 

--- a/crates/appearance-path-tracer-gpu/assets/shaders/apply_di.wgsl
+++ b/crates/appearance-path-tracer-gpu/assets/shaders/apply_di.wgsl
@@ -81,12 +81,14 @@ fn main(@builtin(global_invocation_id) global_id: vec3<u32>,
     let tangent_to_world: mat3x3<f32> = build_orthonormal_basis(front_facing_shading_normal_ws);
     let world_to_tangent: mat3x3<f32> = transpose(tangent_to_world);
 
+    let light_sample_eval_data = LightSample::load_eval_data(light_sample, hit_point_ws);
+
     let front_facing_clearcoat_normal_ws: vec3<f32> = PackedNormalizedXyz10::unpack(light_sample_ctx.front_facing_clearcoat_normal_ws, 0);
     let clearcoat_tangent_to_world: mat3x3<f32> = build_orthonormal_basis(front_facing_clearcoat_normal_ws);
     let clearcoat_world_to_tangent: mat3x3<f32> = transpose(clearcoat_tangent_to_world);
 
-    let shadow_direction: vec3<f32> = normalize(light_sample.point - hit_point_ws);
-    let shadow_distance: f32 = distance(light_sample.point, hit_point_ws);
+    let shadow_direction: vec3<f32> = normalize(light_sample_eval_data.point_ws - hit_point_ws);
+    let shadow_distance: f32 = distance(light_sample_eval_data.point_ws, hit_point_ws);
     let n_dot_l: f32 = dot(shadow_direction, front_facing_shading_normal_ws);
     if (n_dot_l > 0.0) {
         if (trace_shadow_ray(hit_point_ws, shadow_direction, shadow_distance, front_facing_shading_normal_ws, scene)) {
@@ -97,9 +99,7 @@ fn main(@builtin(global_invocation_id) global_id: vec3<u32>,
             let reflectance: vec3<f32> = DisneyBsdf::evaluate(disney_bsdf, front_facing_shading_normal_ws, tangent_to_world, world_to_tangent, clearcoat_tangent_to_world, clearcoat_world_to_tangent,
                 w_out_worldspace, w_in_worldspace, &shading_pdf);
 
-            let light_intensity: vec3<f32> = LightSample::intensity(light_sample, hit_point_ws) * light_sample.emission;
-
-            let contribution: vec3<f32> = throughput * reflectance * light_intensity * n_dot_l * di_reservoir.contribution_weight;
+            let contribution: vec3<f32> = throughput * reflectance * light_sample_eval_data.emission * n_dot_l * di_reservoir.contribution_weight;
             accumulated += contribution;
         };
     }

--- a/crates/appearance-path-tracer-gpu/assets/shaders/helpers/inline_path_tracer.wgsl
+++ b/crates/appearance-path-tracer-gpu/assets/shaders/helpers/inline_path_tracer.wgsl
@@ -130,7 +130,7 @@ fn InlinePathTracer::trace(_origin: vec3<f32>, _direction: vec3<f32>, max_bounce
 
                 let di_reservoir: DiReservoir = Nee::sample_ris(hit_point_ws, w_out_worldspace, front_facing_shading_normal_ws,
                     tangent_to_world, world_to_tangent, clearcoat_tangent_to_world, clearcoat_world_to_tangent,
-                    disney_bsdf, rng, scene);
+                    disney_bsdf, safely_traced_t(intersection.t), back_face, rng, scene);
                 let light_sample: LightSample = di_reservoir.sample;
                 if (di_reservoir.contribution_weight > 0.0) {
                     let shadow_direction: vec3<f32> = normalize(light_sample.point - hit_point_ws);

--- a/crates/appearance-path-tracer-gpu/assets/shaders/helpers/inline_path_tracer.wgsl
+++ b/crates/appearance-path-tracer-gpu/assets/shaders/helpers/inline_path_tracer.wgsl
@@ -32,8 +32,8 @@ fn InlinePathTracer::trace(_origin: vec3<f32>, _direction: vec3<f32>, max_bounce
 
             let intersection = rayQueryGetCommittedIntersection(&rq);
             if (intersection.kind == RAY_QUERY_INTERSECTION_TRIANGLE) {
-                let vertex_pool_slice_index: u32 = intersection.instance_custom_data;
-                let vertex_pool_slice: VertexPoolSlice = vertex_pool_slices[vertex_pool_slice_index];
+                let blas_instance: BlasInstance = blas_instances[intersection.instance_custom_data];
+                let vertex_pool_slice: VertexPoolSlice = vertex_pool_slices[blas_instance.vertex_pool_slice_index];
 
                 let barycentrics = vec3<f32>(1.0 - intersection.barycentrics.x - intersection.barycentrics.y, intersection.barycentrics);
 

--- a/crates/appearance-path-tracer-gpu/assets/shaders/helpers/inline_path_tracer.wgsl
+++ b/crates/appearance-path-tracer-gpu/assets/shaders/helpers/inline_path_tracer.wgsl
@@ -32,8 +32,7 @@ fn InlinePathTracer::trace(_origin: vec3<f32>, _direction: vec3<f32>, max_bounce
 
             let intersection = rayQueryGetCommittedIntersection(&rq);
             if (intersection.kind == RAY_QUERY_INTERSECTION_TRIANGLE) {
-                let blas_instance: BlasInstance = blas_instances[intersection.instance_custom_data];
-                let vertex_pool_slice: VertexPoolSlice = vertex_pool_slices[blas_instance.vertex_pool_slice_index];
+                let vertex_pool_slice: VertexPoolSlice = vertex_pool_slices[intersection.instance_custom_data];
 
                 let barycentrics = vec3<f32>(1.0 - intersection.barycentrics.x - intersection.barycentrics.y, intersection.barycentrics);
 

--- a/crates/appearance-path-tracer-gpu/assets/shaders/helpers/inline_path_tracer.wgsl
+++ b/crates/appearance-path-tracer-gpu/assets/shaders/helpers/inline_path_tracer.wgsl
@@ -58,7 +58,7 @@ fn InlinePathTracer::trace(_origin: vec3<f32>, _direction: vec3<f32>, max_bounce
                         safe_origin_normal = normalize(cross(p01, p02));
     
                         // TODO: non-opaque geometry would be a better choice, not properly supported by wgpu yet
-                        origin += direction * safely_traced_t(intersection.t);
+                        origin += direction * intersection.t;
                         continue;
                     } else {
                         material_color.a = 1.0;
@@ -82,7 +82,7 @@ fn InlinePathTracer::trace(_origin: vec3<f32>, _direction: vec3<f32>, max_bounce
                 let hit_tangent_ws: vec3<f32> = normalize((local_to_world_inv_trans * vec4<f32>(tbn[0], 1.0)).xyz);
                 let hit_bitangent_ws: vec3<f32> = normalize((local_to_world_inv_trans * vec4<f32>(tbn[1], 1.0)).xyz);
                 var hit_normal_ws: vec3<f32> = normalize((local_to_world_inv_trans * vec4<f32>(tbn[2], 1.0)).xyz);
-                let hit_point_ws = origin + direction * safely_traced_t(intersection.t);
+                let hit_point_ws = origin + direction * intersection.t;
 
                 let hit_tangent_to_world = mat3x3<f32>(
                     hit_tangent_ws,
@@ -130,7 +130,7 @@ fn InlinePathTracer::trace(_origin: vec3<f32>, _direction: vec3<f32>, max_bounce
 
                 let di_reservoir: DiReservoir = Nee::sample_ris(hit_point_ws, w_out_worldspace, front_facing_shading_normal_ws,
                     tangent_to_world, world_to_tangent, clearcoat_tangent_to_world, clearcoat_world_to_tangent,
-                    disney_bsdf, safely_traced_t(intersection.t), back_face, rng, scene);
+                    disney_bsdf, intersection.t, back_face, rng, scene);
                 let light_sample: LightSample = di_reservoir.sample;
                 if (di_reservoir.contribution_weight > 0.0) {
                     let shadow_direction: vec3<f32> = normalize(light_sample.point - hit_point_ws);
@@ -173,7 +173,7 @@ fn InlinePathTracer::trace(_origin: vec3<f32>, _direction: vec3<f32>, max_bounce
                     var specular: bool;
                     let reflectance: vec3<f32> = DisneyBsdf::sample(disney_bsdf,
                         front_facing_shading_normal_ws, tangent_to_world, world_to_tangent, clearcoat_tangent_to_world, clearcoat_world_to_tangent,
-                        w_out_worldspace, safely_traced_t(intersection.t), back_face,
+                        w_out_worldspace, intersection.t, back_face,
                         random_uniform_float(rng), random_uniform_float(rng), random_uniform_float(rng),
                         &w_in_worldspace, &pdf, &specular
                     );

--- a/crates/appearance-path-tracer-gpu/assets/shaders/helpers/inline_path_tracer.wgsl
+++ b/crates/appearance-path-tracer-gpu/assets/shaders/helpers/inline_path_tracer.wgsl
@@ -133,8 +133,10 @@ fn InlinePathTracer::trace(_origin: vec3<f32>, _direction: vec3<f32>, max_bounce
                     disney_bsdf, intersection.t, back_face, rng, scene);
                 let light_sample: LightSample = di_reservoir.sample;
                 if (di_reservoir.contribution_weight > 0.0) {
-                    let shadow_direction: vec3<f32> = normalize(light_sample.point - hit_point_ws);
-                    let shadow_distance: f32 = distance(light_sample.point, hit_point_ws);
+                    let light_sample_eval_data = LightSample::load_eval_data(light_sample, hit_point_ws);
+
+                    let shadow_direction: vec3<f32> = normalize(light_sample_eval_data.point_ws - hit_point_ws);
+                    let shadow_distance: f32 = distance(light_sample_eval_data.point_ws, hit_point_ws);
                     let n_dot_l: f32 = dot(shadow_direction, front_facing_shading_normal_ws);
 
                     if (n_dot_l > 0.0) {
@@ -145,9 +147,7 @@ fn InlinePathTracer::trace(_origin: vec3<f32>, _direction: vec3<f32>, max_bounce
                             let reflectance: vec3<f32> = DisneyBsdf::evaluate(disney_bsdf, front_facing_shading_normal_ws, tangent_to_world, world_to_tangent, clearcoat_tangent_to_world, clearcoat_world_to_tangent,
                                 w_out_worldspace, w_in_worldspace, &shading_pdf);
 
-                            let light_intensity: vec3<f32> = LightSample::intensity(light_sample, hit_point_ws) * light_sample.emission;
-
-                            let contribution: vec3<f32> = (*throughput) * reflectance * light_intensity * n_dot_l * di_reservoir.contribution_weight;
+                            let contribution: vec3<f32> = (*throughput) * reflectance * light_sample_eval_data.emission * n_dot_l * di_reservoir.contribution_weight;
                             accumulated += contribution;
                         };
                     }

--- a/crates/appearance-path-tracer-gpu/assets/shaders/helpers/nee.wgsl
+++ b/crates/appearance-path-tracer-gpu/assets/shaders/helpers/nee.wgsl
@@ -264,7 +264,7 @@ fn Nee::sample_ris(hit_point_ws: vec3<f32>, w_out_worldspace: vec3<f32>, front_f
     //     DiReservoir::update(&di_reservoir, weight, rng, sample, phat);
     // }
 
-    const NUM_AREA_SAMPLES: u32 = 0;
+    const NUM_AREA_SAMPLES: u32 = 4;
     const NUM_BSDF_SAMPLES: u32 = 1;
 
     var di_reservoir = DiReservoir::new();
@@ -325,30 +325,6 @@ fn Nee::sample_ris(hit_point_ws: vec3<f32>, w_out_worldspace: vec3<f32>, front_f
                     if (BlasInstance::is_emissive(blas_instance)) {
                         bsdf_light_sample = LightSample::new_triangle_sample(intersection.barycentrics, blas_instance.emissive_blas_instance_idx, intersection.primitive_index);
                     }
-
-                    // let i0: u32 = vertex_indices[vertex_pool_slice.first_index + intersection.primitive_index * 3 + 0];
-                    // let i1: u32 = vertex_indices[vertex_pool_slice.first_index + intersection.primitive_index * 3 + 1];
-                    // let i2: u32 = vertex_indices[vertex_pool_slice.first_index + intersection.primitive_index * 3 + 2];
-
-                    // let v0: Vertex = PackedVertex::unpack(vertices[vertex_pool_slice.first_vertex + i0]);
-                    // let v1: Vertex = PackedVertex::unpack(vertices[vertex_pool_slice.first_vertex + i1]);
-                    // let v2: Vertex = PackedVertex::unpack(vertices[vertex_pool_slice.first_vertex + i2]);
-
-                    // let tex_coord: vec2<f32> = v0.tex_coord * barycentrics.x + v1.tex_coord * barycentrics.y + v2.tex_coord * barycentrics.z;
-
-                    // let material_idx: u32 = vertex_pool_slice.material_idx + triangle_material_indices[vertex_pool_slice.first_index / 3 + intersection.primitive_index];
-                    // let material_descriptor: MaterialDescriptor = material_descriptors[material_idx];
-                    // let material: Material = Material::from_material_descriptor(material_descriptor, tex_coord);
-                    // if (dot(material.emission, material.emission) > 0.0 || true) {
-                    //     var triangle = Triangle::new(
-                    //         (intersection.object_to_world * vec4<f32>(v0.position, 1.0)).xyz,
-                    //         (intersection.object_to_world * vec4<f32>(v1.position, 1.0)).xyz,
-                    //         (intersection.object_to_world * vec4<f32>(v2.position, 1.0)).xyz
-                    //     );
-                    //     let point: vec3<f32> = hit_point_ws + w_in_worldspace * intersection.t;
-
-                    //     bsdf_light_sample = LightSample::new_triangle_sample(point, material.emission, triangle);
-                    // }
                 } else {
                     let uv: vec2<f32> = Sky::inverse_direction_to_sun(w_in_worldspace);
                     bsdf_light_sample = LightSample::new_sun_sample(uv);

--- a/crates/appearance-path-tracer-gpu/assets/shaders/helpers/nee.wgsl
+++ b/crates/appearance-path-tracer-gpu/assets/shaders/helpers/nee.wgsl
@@ -19,8 +19,7 @@ fn LightSample::intensity(_self: LightSample, hit_point_ws: vec3<f32>) -> f32 {
     if (_self.triangle_area == 0.0) {
         return Sky::sun_intensity(direction.y);
     } else {
-        let cos_out: f32 = max(dot(_self.triangle_normal, -direction), 0.0);
-        return Triangle::solid_angle(cos_out, _self.triangle_area, distance) * 10.0;
+        return Triangle::solid_angle(_self.triangle_normal, direction, distance) * 10.0;
     }
 }
 
@@ -49,7 +48,13 @@ fn Nee::sample_emissive_triangle(r0: f32, r1: f32, r23: vec2<f32>, sample_point:
             triangle = Triangle::transform(triangle, emissive_triangle_instance.transform);
             let point: vec3<f32> = triangle.p0 * barycentrics.x + triangle.p1 * barycentrics.y + triangle.p2 * barycentrics.z;
 
-            *pdf = max(1e-6, (1.0 - sun_pick_probability) / f32(vertex_pool_constants.num_emissive_triangles));
+            let p01: vec3<f32> = triangle.p1 - triangle.p0;
+            let p02: vec3<f32> = triangle.p2 - triangle.p0;
+            let triangle_area: f32 = Triangle::area_from_edges(p01, p02);
+
+            *pdf = 1.0 / f32(vertex_pool_constants.num_emissive_triangles);
+            *pdf /= triangle_area;
+            *pdf = max(1e-6, (*pdf) * (1.0 - sun_pick_probability));
 
             let material_idx: u32 = vertex_pool_slice.material_idx + triangle_material_indices[vertex_pool_slice.first_index / 3 + local_triangle_idx];
             let material_descriptor: MaterialDescriptor = material_descriptors[material_idx];
@@ -59,16 +64,16 @@ fn Nee::sample_emissive_triangle(r0: f32, r1: f32, r23: vec2<f32>, sample_point:
         }
     }
 
+    // TODO: double check if this every happens, it should never!
     *pdf = 0.0;
     return LightSample::empty();
 }
 
 fn Nee::sample_sun(r01: vec2<f32>, sun_pick_probability: f32, pdf: ptr<function, f32>) -> LightSample {
     let direction: vec3<f32> =  Sky::direction_to_sun(r01);
-    let distance: f32 = 1000000.0;
     *pdf = sun_pick_probability;
     let emission = sky_constants.sun_color;
-    let point: vec3<f32> = direction * distance;
+    let point: vec3<f32> = direction * SUN_DISTANCE;
 
     return LightSample::new_sun_sample(point, emission);
 }
@@ -81,6 +86,9 @@ fn Nee::sample_uniform(r0: f32, r1: f32, r2: f32, r34: vec2<f32>, sample_point: 
         sun_pick_probability = 1.0;
     }
 
+    // TODO: including sun makes the m_i = 1 / M weight invalid, use MIS?
+    sun_pick_probability = 0.0;
+
     if (r0 < sun_pick_probability) {
         return Nee::sample_sun(r34, sun_pick_probability, pdf);
     } else {
@@ -88,49 +96,232 @@ fn Nee::sample_uniform(r0: f32, r1: f32, r2: f32, r34: vec2<f32>, sample_point: 
     }
 }
 
+// 𝑚𝑖(𝑥) = 𝑝1(𝑥) / (𝑀1𝑝1(𝑥) + 𝑀2𝑝2(𝑥))
+fn balance_heuristic(pdf1: f32, sample_count1: f32, pdf2: f32, sample_count2: f32) -> f32 {
+    return pdf1 / (sample_count1 * pdf1 + sample_count2 * pdf2);
+}
+
 fn Nee::sample_ris(hit_point_ws: vec3<f32>, w_out_worldspace: vec3<f32>, front_facing_shading_normal_ws: vec3<f32>,
      tangent_to_world: mat3x3<f32>, world_to_tangent: mat3x3<f32>, clearcoat_tangent_to_world: mat3x3<f32>, clearcoat_world_to_tangent: mat3x3<f32>,
-     disney_bsdf: DisneyBsdf, rng: ptr<function, u32>, scene: acceleration_structure) -> DiReservoir {
-    const NUM_SAMPLES: u32 = 4;
+     disney_bsdf: DisneyBsdf, t: f32, back_face: bool, rng: ptr<function, u32>, scene: acceleration_structure) -> DiReservoir {
+    // var bsdf_sample_pdf: f32 = 0.0;
+    // var bsdf_light_sample = LightSample::empty();
+    // var bsdf_phat: f32 = 0.0;
+    // var w_in_worldspace: vec3<f32>;
+    // var specular: bool;
+    // let reflectance: vec3<f32> = DisneyBsdf::sample(disney_bsdf,
+    //     front_facing_shading_normal_ws, tangent_to_world, world_to_tangent, clearcoat_tangent_to_world, clearcoat_world_to_tangent,
+    //     w_out_worldspace, t, back_face,
+    //     random_uniform_float(rng), random_uniform_float(rng), random_uniform_float(rng),
+    //     &w_in_worldspace, &bsdf_sample_pdf, &specular
+    // );
+
+    // let wi_dot_n: f32 = abs(dot(w_in_worldspace, front_facing_shading_normal_ws));
+    // let contribution: vec3<f32> = wi_dot_n * reflectance;
+
+    // if (dot(contribution, contribution) > 0.0) {
+    //     // TODO: non-opaques
+    //     var rq: ray_query;
+    //     rayQueryInitialize(&rq, scene, RayDesc(0u, 0xFFu, 0.0, 1000.0, safe_origin(hit_point_ws, front_facing_shading_normal_ws), w_in_worldspace));
+    //     rayQueryProceed(&rq);
+    //     let intersection = rayQueryGetCommittedIntersection(&rq);
+    //     if (intersection.kind == RAY_QUERY_INTERSECTION_TRIANGLE) {
+    //         let vertex_pool_slice_index: u32 = intersection.instance_custom_data;
+    //         let vertex_pool_slice: VertexPoolSlice = vertex_pool_slices[vertex_pool_slice_index];
+
+    //         let barycentrics = vec3<f32>(1.0 - intersection.barycentrics.x - intersection.barycentrics.y, intersection.barycentrics);
+
+    //         let i0: u32 = vertex_indices[vertex_pool_slice.first_index + intersection.primitive_index * 3 + 0];
+    //         let i1: u32 = vertex_indices[vertex_pool_slice.first_index + intersection.primitive_index * 3 + 1];
+    //         let i2: u32 = vertex_indices[vertex_pool_slice.first_index + intersection.primitive_index * 3 + 2];
+
+    //         let v0: Vertex = PackedVertex::unpack(vertices[vertex_pool_slice.first_vertex + i0]);
+    //         let v1: Vertex = PackedVertex::unpack(vertices[vertex_pool_slice.first_vertex + i1]);
+    //         let v2: Vertex = PackedVertex::unpack(vertices[vertex_pool_slice.first_vertex + i2]);
+
+    //         let tex_coord: vec2<f32> = v0.tex_coord * barycentrics.x + v1.tex_coord * barycentrics.y + v2.tex_coord * barycentrics.z;
+
+    //         let material_idx: u32 = vertex_pool_slice.material_idx + triangle_material_indices[vertex_pool_slice.first_index / 3 + intersection.primitive_index];
+    //         let material_descriptor: MaterialDescriptor = material_descriptors[material_idx];
+    //         let material: Material = Material::from_material_descriptor(material_descriptor, tex_coord);
+    //         if (dot(material.emission, material.emission) > 0.0) {
+    //             var triangle = Triangle::new(
+    //                 (intersection.object_to_world * vec4<f32>(v0.position, 1.0)).xyz,
+    //                 (intersection.object_to_world * vec4<f32>(v1.position, 1.0)).xyz,
+    //                 (intersection.object_to_world * vec4<f32>(v2.position, 1.0)).xyz
+    //             );
+    //             let point: vec3<f32> = hit_point_ws + w_in_worldspace * safely_traced_t(intersection.t - 0.01);
+
+    //             //let barycentrics = vec3<f32>(1.0 - intersection.barycentrics.x - intersection.barycentrics.y, intersection.barycentrics);
+    //             //let point: vec3<f32> = triangle.p0 * barycentrics.x + triangle.p1 * barycentrics.y + triangle.p2 * barycentrics.z;
+
+    //             bsdf_light_sample = LightSample::new_triangle_sample(point, material.emission, triangle);
+
+    //             let sample_emission: vec3<f32> = LightSample::intensity(bsdf_light_sample, hit_point_ws) * material.emission; // TODO: move down
+    //             bsdf_phat = linear_to_luma(contribution * sample_emission);
+
+    //             return DiReservoir(1.0, 1.0 / bsdf_sample_pdf, 0.0, 0.0, bsdf_light_sample);
+    //         }
+    //     }
+    // }
+
+    // return DiReservoir(0.0, 0.0, 0.0, 0.0, LightSample::empty());
+
+    // var sample_pdf: f32;
+    // let sample: LightSample = Nee::sample_uniform(random_uniform_float(rng), random_uniform_float(rng), random_uniform_float(rng),
+    //     vec2<f32>(random_uniform_float(rng), random_uniform_float(rng)), hit_point_ws, &sample_pdf);
+    // return DiReservoir(1.0, 1.0 / sample_pdf, 0.0, 0.0, sample);
+
+    // const NUM_SAMPLES: u32 = 32;
+
+    // var di_reservoir = DiReservoir::new();
+
+    // for (var i: u32 = 0; i < NUM_SAMPLES; i += 1) {
+    //     var sample_pdf: f32;
+    //     let sample: LightSample = Nee::sample_uniform(random_uniform_float(rng), random_uniform_float(rng), random_uniform_float(rng),
+    //         vec2<f32>(random_uniform_float(rng), random_uniform_float(rng)), hit_point_ws, &sample_pdf);
+
+    //     let w_in_worldspace: vec3<f32> = normalize(sample.point - hit_point_ws);
+    //     let n_dot_l: f32 = dot(w_in_worldspace, front_facing_shading_normal_ws);
+
+    //     var phat: f32 = 0.0;
+    //     var weight: f32 = 0.0;
+    //     if (n_dot_l > 0.0 && sample_pdf > 0.0) {
+    //         var shading_pdf: f32;
+    //         let reflectance: vec3<f32> = DisneyBsdf::evaluate(disney_bsdf, front_facing_shading_normal_ws,
+    //             tangent_to_world, world_to_tangent, clearcoat_tangent_to_world, clearcoat_world_to_tangent,
+    //             w_out_worldspace, w_in_worldspace, &shading_pdf);
+            
+    //         if (shading_pdf > 0.0) {
+    //             let contribution: vec3<f32> = n_dot_l * reflectance;
+    //             let sample_intensity: f32 = LightSample::intensity(sample, hit_point_ws);
+    //             phat = linear_to_luma(contribution * sample_intensity);
+
+    //             // 𝑤_𝑖 ← 𝑚_𝑖(𝑋_𝑖) 𝑝ˆ(𝑋_𝑖) 𝑊_𝑋_𝑖
+    //             weight = (1.0 / f32(NUM_SAMPLES)) * phat * (1.0 / sample_pdf);
+    //         }
+    //     }
+
+    //     DiReservoir::update(&di_reservoir, weight, rng, sample, phat);
+    // }
+
+    const NUM_AREA_SAMPLES: u32 = 4;
+    const NUM_BSDF_SAMPLES: u32 = 1;
 
     var di_reservoir = DiReservoir::new();
+    
+    for (var i: u32 = 0; i < max(NUM_AREA_SAMPLES, NUM_BSDF_SAMPLES); i += 1) {
+        var area_sample_pdf: f32 = 0.0;
+        var area_light_sample: LightSample;
+        var area_phat: f32 = 0.0;
+        if (i < NUM_AREA_SAMPLES) {
+            area_light_sample = Nee::sample_uniform(random_uniform_float(rng), random_uniform_float(rng), random_uniform_float(rng),
+                vec2<f32>(random_uniform_float(rng), random_uniform_float(rng)), hit_point_ws, &area_sample_pdf);
 
-    for (var i: u32 = 0; i < NUM_SAMPLES; i += 1) {
-        var sample_pdf: f32;
-        let sample: LightSample = Nee::sample_uniform(random_uniform_float(rng), random_uniform_float(rng), random_uniform_float(rng),
-            vec2<f32>(random_uniform_float(rng), random_uniform_float(rng)), hit_point_ws, &sample_pdf);
+            let w_in_worldspace: vec3<f32> = normalize(area_light_sample.point - hit_point_ws);
+            let n_dot_l: f32 = dot(w_in_worldspace, front_facing_shading_normal_ws);
 
-        let w_in_worldspace: vec3<f32> = normalize(sample.point - hit_point_ws);
-
-        let n_dot_l: f32 = dot(w_in_worldspace, front_facing_shading_normal_ws);
-
-        var phat: f32 = 0.0;
-        var weight: f32 = 0.0;
-        if (n_dot_l > 0.0 && sample_pdf > 0.0) {
-            let sample_intensity = LightSample::intensity(sample, hit_point_ws);
-
-            // TODO: a cheaper approximation of the disney bsdf is desirable here
-            var shading_pdf: f32;
-            let reflectance: vec3<f32> = DisneyBsdf::evaluate(disney_bsdf, front_facing_shading_normal_ws,
-                tangent_to_world, world_to_tangent, clearcoat_tangent_to_world, clearcoat_world_to_tangent,
-                w_out_worldspace, w_in_worldspace, &shading_pdf);
-            
-            if (shading_pdf > 0.0) {
-                let contribution: vec3<f32> = n_dot_l * reflectance;
-                phat = linear_to_luma(contribution * sample_intensity);
-                weight = phat / sample_pdf;
+            if (n_dot_l > 0.0 && area_sample_pdf > 0.0) {
+                var shading_pdf: f32;
+                let reflectance: vec3<f32> = DisneyBsdf::evaluate(disney_bsdf, front_facing_shading_normal_ws,
+                    tangent_to_world, world_to_tangent, clearcoat_tangent_to_world, clearcoat_world_to_tangent,
+                    w_out_worldspace, w_in_worldspace, &shading_pdf);
+                
+                if (shading_pdf > 0.0) {
+                    let contribution: vec3<f32> = n_dot_l * reflectance;
+                    let sample_emission: vec3<f32> = LightSample::intensity(area_light_sample, hit_point_ws) * area_light_sample.emission;
+                    area_phat = linear_to_luma(contribution * sample_emission);
+                }
             }
         }
 
-        DiReservoir::update(&di_reservoir, weight, rng, sample, phat);
+        var bsdf_sample_pdf: f32 = 0.0;
+        var bsdf_light_sample = LightSample::empty();
+        var bsdf_phat: f32 = 0.0;
+        if (i < NUM_BSDF_SAMPLES) {
+            var w_in_worldspace: vec3<f32>;
+            var specular: bool;
+            let reflectance: vec3<f32> = DisneyBsdf::sample(disney_bsdf,
+                front_facing_shading_normal_ws, tangent_to_world, world_to_tangent, clearcoat_tangent_to_world, clearcoat_world_to_tangent,
+                w_out_worldspace, t, back_face,
+                random_uniform_float(rng), random_uniform_float(rng), random_uniform_float(rng),
+                &w_in_worldspace, &bsdf_sample_pdf, &specular
+            );
+
+            let wi_dot_n: f32 = abs(dot(w_in_worldspace, front_facing_shading_normal_ws));
+            let contribution: vec3<f32> = wi_dot_n * reflectance;
+
+            if (dot(contribution, contribution) > 0.0) {
+                // TODO: non-opaques
+                var rq: ray_query;
+                rayQueryInitialize(&rq, scene, RayDesc(0u, 0xFFu, 0.0, 1000.0, safe_origin(hit_point_ws, front_facing_shading_normal_ws), w_in_worldspace));
+                rayQueryProceed(&rq);
+                let intersection = rayQueryGetCommittedIntersection(&rq);
+                if (intersection.kind == RAY_QUERY_INTERSECTION_TRIANGLE) {
+                    let vertex_pool_slice_index: u32 = intersection.instance_custom_data;
+                    let vertex_pool_slice: VertexPoolSlice = vertex_pool_slices[vertex_pool_slice_index];
+
+                    let barycentrics = vec3<f32>(1.0 - intersection.barycentrics.x - intersection.barycentrics.y, intersection.barycentrics);
+
+                    let i0: u32 = vertex_indices[vertex_pool_slice.first_index + intersection.primitive_index * 3 + 0];
+                    let i1: u32 = vertex_indices[vertex_pool_slice.first_index + intersection.primitive_index * 3 + 1];
+                    let i2: u32 = vertex_indices[vertex_pool_slice.first_index + intersection.primitive_index * 3 + 2];
+
+                    let v0: Vertex = PackedVertex::unpack(vertices[vertex_pool_slice.first_vertex + i0]);
+                    let v1: Vertex = PackedVertex::unpack(vertices[vertex_pool_slice.first_vertex + i1]);
+                    let v2: Vertex = PackedVertex::unpack(vertices[vertex_pool_slice.first_vertex + i2]);
+
+                    let tex_coord: vec2<f32> = v0.tex_coord * barycentrics.x + v1.tex_coord * barycentrics.y + v2.tex_coord * barycentrics.z;
+
+                    let material_idx: u32 = vertex_pool_slice.material_idx + triangle_material_indices[vertex_pool_slice.first_index / 3 + intersection.primitive_index];
+                    let material_descriptor: MaterialDescriptor = material_descriptors[material_idx];
+                    let material: Material = Material::from_material_descriptor(material_descriptor, tex_coord);
+                    if (dot(material.emission, material.emission) > 0.0 || true) {
+                        var triangle = Triangle::new(
+                            (intersection.object_to_world * vec4<f32>(v0.position, 1.0)).xyz,
+                            (intersection.object_to_world * vec4<f32>(v1.position, 1.0)).xyz,
+                            (intersection.object_to_world * vec4<f32>(v2.position, 1.0)).xyz
+                        );
+                        let point: vec3<f32> = hit_point_ws + w_in_worldspace * safely_traced_t(intersection.t - 0.01);
+
+                        bsdf_light_sample = LightSample::new_triangle_sample(point, material.emission, triangle);
+                    }
+                } else {
+                    //bsdf_light_sample = LightSample::new_sun_sample(w_in_worldspace * SUN_DISTANCE, sky_constants.sun_color);
+                }
+
+                if (!LightSample::is_empty(bsdf_light_sample)) {
+                    let sample_emission: vec3<f32> = LightSample::intensity(bsdf_light_sample, hit_point_ws) * bsdf_light_sample.emission;
+                    bsdf_phat = linear_to_luma(contribution * sample_emission);
+                }
+            }
+        }
+
+        
+        if (i < NUM_AREA_SAMPLES) {
+            let mis_weight: f32 = balance_heuristic(area_sample_pdf, f32(NUM_AREA_SAMPLES), bsdf_sample_pdf, f32(NUM_BSDF_SAMPLES));
+
+            // 𝑤_𝑖 ← 𝑚_𝑖(𝑋_𝑖) 𝑝ˆ(𝑋_𝑖) 𝑊_𝑋_𝑖
+            let weight: f32 = mis_weight * area_phat * (1.0 / max(area_sample_pdf, 1e-8));
+            DiReservoir::update(&di_reservoir, weight, rng, area_light_sample, area_phat);
+        }
+
+        if (i < NUM_BSDF_SAMPLES) {
+            let mis_weight: f32 = balance_heuristic(bsdf_sample_pdf, f32(NUM_BSDF_SAMPLES), area_sample_pdf, f32(NUM_AREA_SAMPLES));
+
+            // 𝑤_𝑖 ← 𝑚_𝑖(𝑋_𝑖) 𝑝ˆ(𝑋_𝑖) 𝑊_𝑋_𝑖
+            let weight: f32 = mis_weight * bsdf_phat * (1.0 / max(bsdf_sample_pdf, 1e-8));
+            DiReservoir::update(&di_reservoir, weight, rng, bsdf_light_sample, bsdf_phat);
+        }
     }
 
-    if (di_reservoir.selected_phat > RESTIR_DI_EPSILON && di_reservoir.sample_count * di_reservoir.weight_sum > RESTIR_DI_EPSILON) {
+    if (di_reservoir.selected_phat > RESTIR_DI_EPSILON) {
         let direction: vec3<f32> = normalize(di_reservoir.sample.point - hit_point_ws);
         let distance: f32 = distance(di_reservoir.sample.point, hit_point_ws);
 
         if (trace_shadow_ray(hit_point_ws, direction, distance, front_facing_shading_normal_ws, scene)) {
-            di_reservoir.contribution_weight = (1.0 / di_reservoir.selected_phat) * (1.0 / di_reservoir.sample_count * di_reservoir.weight_sum);
+            // 𝑟.𝑊_𝑌 ← (1 / 𝑝ˆ(𝑟.𝑌)) 𝑟.𝑤_sum
+            di_reservoir.contribution_weight = (1.0 / di_reservoir.selected_phat) * di_reservoir.weight_sum;
         }
     }
 

--- a/crates/appearance-path-tracer-gpu/assets/shaders/helpers/nee.wgsl
+++ b/crates/appearance-path-tracer-gpu/assets/shaders/helpers/nee.wgsl
@@ -17,7 +17,7 @@ fn LightSample::intensity(_self: LightSample, hit_point_ws: vec3<f32>) -> f32 {
     let distance: f32 = distance(_self.point, hit_point_ws);
 
     if (_self.triangle_area == 0.0) {
-        return Sky::sun_intensity(direction.y);
+        return Sky::sun_intensity(direction);
     } else {
         return Triangle::solid_angle(_self.triangle_normal, direction, distance) * 10.0;
     }
@@ -85,9 +85,6 @@ fn Nee::sample_uniform(r0: f32, r1: f32, r2: f32, r34: vec2<f32>, sample_point: 
     } else {
         sun_pick_probability = 1.0;
     }
-
-    // TODO: including sun makes the m_i = 1 / M weight invalid, use MIS?
-    sun_pick_probability = 0.0;
 
     if (r0 < sun_pick_probability) {
         return Nee::sample_sun(r34, sun_pick_probability, pdf);
@@ -287,7 +284,7 @@ fn Nee::sample_ris(hit_point_ws: vec3<f32>, w_out_worldspace: vec3<f32>, front_f
                         bsdf_light_sample = LightSample::new_triangle_sample(point, material.emission, triangle);
                     }
                 } else {
-                    //bsdf_light_sample = LightSample::new_sun_sample(w_in_worldspace * SUN_DISTANCE, sky_constants.sun_color);
+                    bsdf_light_sample = LightSample::new_sun_sample(w_in_worldspace * SUN_DISTANCE, sky_constants.sun_color);
                 }
 
                 if (!LightSample::is_empty(bsdf_light_sample)) {

--- a/crates/appearance-path-tracer-gpu/assets/shaders/helpers/nee.wgsl
+++ b/crates/appearance-path-tracer-gpu/assets/shaders/helpers/nee.wgsl
@@ -320,7 +320,7 @@ fn Nee::sample_ris(hit_point_ws: vec3<f32>, w_out_worldspace: vec3<f32>, front_f
                 rayQueryProceed(&rq);
                 let intersection = rayQueryGetCommittedIntersection(&rq);
                 if (intersection.kind == RAY_QUERY_INTERSECTION_TRIANGLE) {
-                    let blas_instance: BlasInstance = blas_instances[intersection.instance_custom_data];
+                    let blas_instance: BlasInstance = blas_instances[intersection.instance_index];
 
                     if (BlasInstance::is_emissive(blas_instance)) {
                         bsdf_light_sample = LightSample::new_triangle_sample(intersection.barycentrics, blas_instance.emissive_blas_instance_idx, intersection.primitive_index);

--- a/crates/appearance-path-tracer-gpu/assets/shaders/helpers/trace.wgsl
+++ b/crates/appearance-path-tracer-gpu/assets/shaders/helpers/trace.wgsl
@@ -17,10 +17,6 @@ fn safe_distance(distance: f32) -> f32 {
     return distance - TRACE_EPSILON * 2.0;
 }
 
-fn safely_traced_t(t: f32) -> f32 {
-    return t + TRACE_EPSILON;
-}
-
 fn trace_shadow_ray_opaque(origin: vec3<f32>, direction: vec3<f32>, distance: f32, scene: acceleration_structure) -> bool {
     var shadow_rq: ray_query;
     rayQueryInitialize(&shadow_rq, scene, RayDesc(0x4, 0xFFu, 0.0, distance, origin + direction * 0.00001, direction));
@@ -74,8 +70,8 @@ fn trace_shadow_ray(_origin: vec3<f32>, direction: vec3<f32>, distance: f32, nor
                 safe_origin_normal = normalize(cross(p01, p02));
 
                 // TODO: non-opaque geometry would be a better choice, not properly supported by wgpu yet
-                origin += direction * safely_traced_t(intersection.t);
-                travelled_distance += safely_traced_t(intersection.t);
+                origin += direction * intersection.t;
+                travelled_distance += intersection.t;
                 continue; // check if last? return false if so
             }
 

--- a/crates/appearance-path-tracer-gpu/assets/shaders/helpers/trace.wgsl
+++ b/crates/appearance-path-tracer-gpu/assets/shaders/helpers/trace.wgsl
@@ -17,9 +17,9 @@ fn safe_distance(distance: f32) -> f32 {
     return distance - TRACE_EPSILON * 2.0;
 }
 
-fn trace_shadow_ray_opaque(origin: vec3<f32>, direction: vec3<f32>, distance: f32, scene: acceleration_structure) -> bool {
+fn trace_shadow_ray_opaque(origin: vec3<f32>, direction: vec3<f32>, distance: f32, normal: vec3<f32>, scene: acceleration_structure) -> bool {
     var shadow_rq: ray_query;
-    rayQueryInitialize(&shadow_rq, scene, RayDesc(0x4, 0xFFu, 0.0, distance, origin + direction * 0.00001, direction));
+    rayQueryInitialize(&shadow_rq, scene, RayDesc(0x4, 0xFFu, 0.0, safe_distance(distance), safe_origin(origin, normal), direction));
     rayQueryProceed(&shadow_rq);
     let intersection = rayQueryGetCommittedIntersection(&shadow_rq);
     return intersection.kind != RAY_QUERY_INTERSECTION_TRIANGLE;
@@ -29,7 +29,7 @@ fn trace_shadow_ray(_origin: vec3<f32>, direction: vec3<f32>, distance: f32, nor
     var origin: vec3<f32> = _origin;
 
     if (MAX_NON_OPAQUE_SHADOW_DEPTH == 1) {
-        return trace_shadow_ray_opaque(origin, direction, distance, scene);
+        return trace_shadow_ray_opaque(origin, direction, distance, normal, scene);
     }
 
     var travelled_distance: f32 = 0.0;

--- a/crates/appearance-path-tracer-gpu/assets/shaders/helpers/trace.wgsl
+++ b/crates/appearance-path-tracer-gpu/assets/shaders/helpers/trace.wgsl
@@ -45,8 +45,8 @@ fn trace_shadow_ray(_origin: vec3<f32>, direction: vec3<f32>, distance: f32, nor
 
         let intersection = rayQueryGetCommittedIntersection(&rq);
         if (intersection.kind == RAY_QUERY_INTERSECTION_TRIANGLE) {
-            let vertex_pool_slice_index: u32 = intersection.instance_custom_data;
-            let vertex_pool_slice: VertexPoolSlice = vertex_pool_slices[vertex_pool_slice_index];
+            let blas_instance: BlasInstance = blas_instances[intersection.instance_custom_data];
+            let vertex_pool_slice: VertexPoolSlice = vertex_pool_slices[blas_instance.vertex_pool_slice_index];
 
             let barycentrics = vec3<f32>(1.0 - intersection.barycentrics.x - intersection.barycentrics.y, intersection.barycentrics);
 

--- a/crates/appearance-path-tracer-gpu/assets/shaders/helpers/trace.wgsl
+++ b/crates/appearance-path-tracer-gpu/assets/shaders/helpers/trace.wgsl
@@ -45,8 +45,7 @@ fn trace_shadow_ray(_origin: vec3<f32>, direction: vec3<f32>, distance: f32, nor
 
         let intersection = rayQueryGetCommittedIntersection(&rq);
         if (intersection.kind == RAY_QUERY_INTERSECTION_TRIANGLE) {
-            let blas_instance: BlasInstance = blas_instances[intersection.instance_custom_data];
-            let vertex_pool_slice: VertexPoolSlice = vertex_pool_slices[blas_instance.vertex_pool_slice_index];
+            let vertex_pool_slice: VertexPoolSlice = vertex_pool_slices[intersection.instance_custom_data];
 
             let barycentrics = vec3<f32>(1.0 - intersection.barycentrics.x - intersection.barycentrics.y, intersection.barycentrics);
 

--- a/crates/appearance-path-tracer-gpu/assets/shaders/raygen.wgsl
+++ b/crates/appearance-path-tracer-gpu/assets/shaders/raygen.wgsl
@@ -1,3 +1,4 @@
+@include ::random
 @include appearance-path-tracer-gpu::shared/ray
 
 struct Constants {
@@ -5,8 +6,8 @@ struct Constants {
     inv_proj: mat4x4<f32>,
     width: u32,
     height: u32,
+    seed: u32,
     _padding0: u32,
-    _padding1: u32,
 }
 
 @group(0)
@@ -23,8 +24,12 @@ fn main(@builtin(global_invocation_id) global_id: vec3<u32>,
     @builtin(num_workgroups) dispatch_size: vec3<u32>) {
     let id: vec2<u32> = global_id.xy;
     if (id.x >= constants.width || id.y >= constants.height) { return; }
+    let flat_id: u32 = id.y * constants.width + id.x;
 
-    let pixel_center = vec2<f32>(f32(id.x) + 0.5, f32(id.y) + 0.5);
+    var rng: u32 = pcg_hash(flat_id ^ xor_shift_u32(constants.seed));
+
+    let pixel_center = vec2<f32>(f32(id.x) + random_uniform_float(&rng), f32(id.y) + random_uniform_float(&rng));
+    //let pixel_center = vec2<f32>(f32(id.x) + 0.5, f32(id.y) + 0.5);
     var uv: vec2<f32> = (pixel_center / vec2<f32>(f32(constants.width), f32(constants.height))) * 2.0 - 1.0;
     uv.y = -uv.y;
     let origin: vec4<f32> = constants.inv_view * vec4<f32>(0.0, 0.0, 0.0, 1.0);

--- a/crates/appearance-path-tracer-gpu/assets/shaders/restir_di_temporal.wgsl
+++ b/crates/appearance-path-tracer-gpu/assets/shaders/restir_di_temporal.wgsl
@@ -114,14 +114,6 @@ fn main(@builtin(global_invocation_id) global_id: vec3<u32>,
         prev_reservoir.selected_phat = LightSample::phat(prev_reservoir.sample, light_sample_ctx, hit_point_ws, w_out_worldspace, constants.unbiased > 0, scene);
 
         reservoir = DiReservoir::combine(reservoir, prev_reservoir, &rng);
-
-        // // pˆ of previous reservoir in the previous pixels context
-        // let p_hat_prev: f32 = LightSample::phat(prev_reservoir.sample, light_sample_ctx, hit_point_ws, w_out_worldspace, false, scene);// TODO: this should be done with prev scene state, but for static scene this is valid
-        // // pˆ of previous reservoir in the current pixels context
-        // let p_hat_current: f32 = LightSample::phat(prev_reservoir.sample, light_sample_ctx, hit_point_ws, w_out_worldspace, false, scene);
-        
-        // // 𝑚𝑖(𝑥) = 𝑝ˆ𝑖(𝑥) / ∑(𝑀, 𝑗=1, 𝑝ˆ𝑗(𝑥))
-        // let mis_weight: f32 = p_hat_current / p_hat_prev;
     }
 
     reservoirs_out[flat_id] = PackedDiReservoir::new(reservoir);

--- a/crates/appearance-path-tracer-gpu/assets/shaders/shared/light_sample.wgsl
+++ b/crates/appearance-path-tracer-gpu/assets/shaders/shared/light_sample.wgsl
@@ -1,23 +1,39 @@
-@include ::triangle
 @include appearance-packing::shared/packing
 
 // Used for sampling lights in the world, can both sample emissive triangles or the sun, indicated by triangle_area = 0
-struct LightSample { // TODO: this will need to be represented as a triangle idx (and some way we can query it's transform), also barycentric coords (usefull for both triangle and sun)
-                     // this will better support moving lights
-    point: vec3<f32>,
+// struct LightSample { // TODO: this will need to be represented as a triangle idx (and some way we can query it's transform), also barycentric coords (usefull for both triangle and sun)
+//                      // this will better support moving lights
+//     point: vec3<f32>,
+//     emission: vec3<f32>,
+//     triangle_area: f32, // TODO: remove?
+//     triangle_normal: vec3<f32>,
+// }
+
+struct LightSampleEvalData {
     emission: vec3<f32>,
-    triangle_area: f32, // TODO: remove?
-    triangle_normal: vec3<f32>,
+    point_ws: vec3<f32>,
+}
+
+struct LightSample {
+    uv: vec2<f32>,
+    emissive_triangle_instance_idx: u32,
+    local_triangle_idx: u32,
 }
 
 // Packed representation of LightSample
+// struct PackedLightSample {
+//     point: vec3<f32>,
+//     emission: PackedRgb9e5,
+//     triangle_area: f32,
+//     triangle_normal: PackedNormalizedXyz10,
+//     _padding0: u32,
+//     _padding1: u32,
+// }
+
 struct PackedLightSample {
-    point: vec3<f32>,
-    emission: PackedRgb9e5,
-    triangle_area: f32,
-    triangle_normal: PackedNormalizedXyz10,
-    _padding0: u32,
-    _padding1: u32,
+    uv: vec2<f32>,
+    emissive_triangle_instance_idx: u32,
+    local_triangle_idx: u32,
 }
 
 // Context required to evaluate a light sample
@@ -29,46 +45,76 @@ struct LightSampleCtx {
     front_facing_clearcoat_normal_ws: PackedNormalizedXyz10,
 }
 
-fn LightSample::new_triangle_sample(point: vec3<f32>, emission: vec3<f32>, triangle: Triangle) -> LightSample {
-    let p01: vec3<f32> = triangle.p1 - triangle.p0;
-    let p02: vec3<f32> = triangle.p2 - triangle.p0;
-    let triangle_area: f32 = Triangle::area_from_edges(p01, p02);
-    let triangle_normal: vec3<f32> = normalize(cross(p01, p02));
+// fn LightSample::new_triangle_sample(point: vec3<f32>, emission: vec3<f32>, triangle: Triangle) -> LightSample {
+//     let p01: vec3<f32> = triangle.p1 - triangle.p0;
+//     let p02: vec3<f32> = triangle.p2 - triangle.p0;
+//     let triangle_area: f32 = Triangle::area_from_edges(p01, p02);
+//     let triangle_normal: vec3<f32> = normalize(cross(p01, p02));
 
-    return LightSample(point, emission, triangle_area, triangle_normal);
+//     return LightSample(point, emission, triangle_area, triangle_normal);
+// }
+
+fn LightSampleEvalData::new(emission: vec3<f32>, point_ws: vec3<f32>) -> LightSampleEvalData {
+    return LightSampleEvalData(emission, point_ws);
 }
 
-fn LightSample::new_sun_sample(point: vec3<f32>, emission: vec3<f32>) -> LightSample {
-    return LightSample(point, emission, 0.0, UP);
+fn LightSampleEvalData::empty() -> LightSampleEvalData {
+    return LightSampleEvalData(vec3<f32>(0.0), vec3<f32>(0.0));
+}
+
+fn LightSample::new_triangle_sample(uv: vec2<f32>, emissive_triangle_instance_idx: u32, local_triangle_idx: u32) -> LightSample {
+    return LightSample(uv, emissive_triangle_instance_idx, local_triangle_idx);
+}
+
+fn LightSample::new_sun_sample(uv: vec2<f32>) -> LightSample {
+    return LightSample(uv, U32_MAX, 0);
 }
 
 fn LightSample::empty() -> LightSample {
-    return LightSample(vec3<f32>(0.0), vec3<f32>(0.0), -1.0, UP);
+    return LightSample(vec2<f32>(-1.0), 0, 0);
 }
-
-// TODO: is_sun check, rename empty to valid
 
 fn LightSample::is_empty(_self: LightSample) -> bool {
-    return _self.triangle_area < -0.0001;
+    return _self.uv.x < -0.0001;
 }
+
+fn LightSample::is_sun(_self: LightSample) -> bool {
+    return _self.emissive_triangle_instance_idx == U32_MAX;
+}
+
+// fn PackedLightSample::new(light_sample: LightSample) -> PackedLightSample {
+//     return PackedLightSample(
+//         light_sample.point,
+//         PackedRgb9e5::new(light_sample.emission),
+//         light_sample.triangle_area,
+//         PackedNormalizedXyz10::new(light_sample.triangle_normal, 0),
+//         0,
+//         0
+//     );
+// }
+
+// fn PackedLightSample::unpack(_self: PackedLightSample) -> LightSample {
+//     return LightSample(
+//         _self.point,
+//         PackedRgb9e5::unpack(_self.emission),
+//         _self.triangle_area,
+//         PackedNormalizedXyz10::unpack(_self.triangle_normal, 0)
+//     );
+// }
 
 fn PackedLightSample::new(light_sample: LightSample) -> PackedLightSample {
     return PackedLightSample(
-        light_sample.point,
-        PackedRgb9e5::new(light_sample.emission),
-        light_sample.triangle_area,
-        PackedNormalizedXyz10::new(light_sample.triangle_normal, 0),
-        0,
-        0
+        light_sample.uv,
+        light_sample.emissive_triangle_instance_idx,
+        light_sample.local_triangle_idx
     );
 }
 
 fn PackedLightSample::unpack(_self: PackedLightSample) -> LightSample {
     return LightSample(
-        _self.point,
-        PackedRgb9e5::unpack(_self.emission),
-        _self.triangle_area,
-        PackedNormalizedXyz10::unpack(_self.triangle_normal, 0)
+        _self.uv,
+        _self.emissive_triangle_instance_idx,
+        _self.local_triangle_idx
     );
 }
 

--- a/crates/appearance-path-tracer-gpu/assets/shaders/shared/light_sample.wgsl
+++ b/crates/appearance-path-tracer-gpu/assets/shaders/shared/light_sample.wgsl
@@ -1,34 +1,17 @@
 @include appearance-packing::shared/packing
 
-// Used for sampling lights in the world, can both sample emissive triangles or the sun, indicated by triangle_area = 0
-// struct LightSample { // TODO: this will need to be represented as a triangle idx (and some way we can query it's transform), also barycentric coords (usefull for both triangle and sun)
-//                      // this will better support moving lights
-//     point: vec3<f32>,
-//     emission: vec3<f32>,
-//     triangle_area: f32, // TODO: remove?
-//     triangle_normal: vec3<f32>,
-// }
-
+// Data required to evaluate a light sample from any given hit position in the world, this must be reevaluated every frame as triangle can move over time & their intensity can change
 struct LightSampleEvalData {
     emission: vec3<f32>,
     point_ws: vec3<f32>,
 }
 
+// Used for sampling lights in the world, can both sample emissive triangles or the sun
 struct LightSample {
     uv: vec2<f32>,
     emissive_triangle_instance_idx: u32,
     local_triangle_idx: u32,
 }
-
-// Packed representation of LightSample
-// struct PackedLightSample {
-//     point: vec3<f32>,
-//     emission: PackedRgb9e5,
-//     triangle_area: f32,
-//     triangle_normal: PackedNormalizedXyz10,
-//     _padding0: u32,
-//     _padding1: u32,
-// }
 
 struct PackedLightSample {
     uv: vec2<f32>,
@@ -44,15 +27,6 @@ struct LightSampleCtx {
     front_facing_shading_normal_ws: PackedNormalizedXyz10,
     front_facing_clearcoat_normal_ws: PackedNormalizedXyz10,
 }
-
-// fn LightSample::new_triangle_sample(point: vec3<f32>, emission: vec3<f32>, triangle: Triangle) -> LightSample {
-//     let p01: vec3<f32> = triangle.p1 - triangle.p0;
-//     let p02: vec3<f32> = triangle.p2 - triangle.p0;
-//     let triangle_area: f32 = Triangle::area_from_edges(p01, p02);
-//     let triangle_normal: vec3<f32> = normalize(cross(p01, p02));
-
-//     return LightSample(point, emission, triangle_area, triangle_normal);
-// }
 
 fn LightSampleEvalData::new(emission: vec3<f32>, point_ws: vec3<f32>) -> LightSampleEvalData {
     return LightSampleEvalData(emission, point_ws);
@@ -81,26 +55,6 @@ fn LightSample::is_empty(_self: LightSample) -> bool {
 fn LightSample::is_sun(_self: LightSample) -> bool {
     return _self.emissive_triangle_instance_idx == U32_MAX - 1;
 }
-
-// fn PackedLightSample::new(light_sample: LightSample) -> PackedLightSample {
-//     return PackedLightSample(
-//         light_sample.point,
-//         PackedRgb9e5::new(light_sample.emission),
-//         light_sample.triangle_area,
-//         PackedNormalizedXyz10::new(light_sample.triangle_normal, 0),
-//         0,
-//         0
-//     );
-// }
-
-// fn PackedLightSample::unpack(_self: PackedLightSample) -> LightSample {
-//     return LightSample(
-//         _self.point,
-//         PackedRgb9e5::unpack(_self.emission),
-//         _self.triangle_area,
-//         PackedNormalizedXyz10::unpack(_self.triangle_normal, 0)
-//     );
-// }
 
 fn PackedLightSample::new(light_sample: LightSample) -> PackedLightSample {
     return PackedLightSample(

--- a/crates/appearance-path-tracer-gpu/assets/shaders/shared/light_sample.wgsl
+++ b/crates/appearance-path-tracer-gpu/assets/shaders/shared/light_sample.wgsl
@@ -2,7 +2,8 @@
 @include appearance-packing::shared/packing
 
 // Used for sampling lights in the world, can both sample emissive triangles or the sun, indicated by triangle_area = 0
-struct LightSample {
+struct LightSample { // TODO: this will need to be represented as a triangle idx (and some way we can query it's transform), also barycentric coords (usefull for both triangle and sun)
+                     // this will better support moving lights
     point: vec3<f32>,
     emission: vec3<f32>,
     triangle_area: f32, // TODO: remove?

--- a/crates/appearance-path-tracer-gpu/assets/shaders/shared/light_sample.wgsl
+++ b/crates/appearance-path-tracer-gpu/assets/shaders/shared/light_sample.wgsl
@@ -67,19 +67,19 @@ fn LightSample::new_triangle_sample(uv: vec2<f32>, emissive_triangle_instance_id
 }
 
 fn LightSample::new_sun_sample(uv: vec2<f32>) -> LightSample {
-    return LightSample(uv, U32_MAX, 0);
+    return LightSample(uv, U32_MAX - 1, 0);
 }
 
 fn LightSample::empty() -> LightSample {
-    return LightSample(vec2<f32>(-1.0), 0, 0);
+    return LightSample(vec2<f32>(0.0), U32_MAX, 0);
 }
 
 fn LightSample::is_empty(_self: LightSample) -> bool {
-    return _self.uv.x < -0.0001;
+    return _self.emissive_triangle_instance_idx == U32_MAX;
 }
 
 fn LightSample::is_sun(_self: LightSample) -> bool {
-    return _self.emissive_triangle_instance_idx == U32_MAX;
+    return _self.emissive_triangle_instance_idx == U32_MAX - 1;
 }
 
 // fn PackedLightSample::new(light_sample: LightSample) -> PackedLightSample {

--- a/crates/appearance-path-tracer-gpu/assets/shaders/shared/light_sample.wgsl
+++ b/crates/appearance-path-tracer-gpu/assets/shaders/shared/light_sample.wgsl
@@ -5,7 +5,7 @@
 struct LightSample {
     point: vec3<f32>,
     emission: vec3<f32>,
-    triangle_area: f32,
+    triangle_area: f32, // TODO: remove?
     triangle_normal: vec3<f32>,
 }
 
@@ -42,7 +42,13 @@ fn LightSample::new_sun_sample(point: vec3<f32>, emission: vec3<f32>) -> LightSa
 }
 
 fn LightSample::empty() -> LightSample {
-    return LightSample(vec3<f32>(0.0), vec3<f32>(0.0), 0.0, UP);
+    return LightSample(vec3<f32>(0.0), vec3<f32>(0.0), -1.0, UP);
+}
+
+// TODO: is_sun check, rename empty to valid
+
+fn LightSample::is_empty(_self: LightSample) -> bool {
+    return _self.triangle_area < -0.0001;
 }
 
 fn PackedLightSample::new(light_sample: LightSample) -> PackedLightSample {

--- a/crates/appearance-path-tracer-gpu/assets/shaders/shared/restir/di_reservoir.wgsl
+++ b/crates/appearance-path-tracer-gpu/assets/shaders/shared/restir/di_reservoir.wgsl
@@ -78,17 +78,17 @@ fn LightSample::phat(_self: LightSample, light_sample_ctx: LightSampleCtx, hit_p
         visibility = trace_shadow_ray(hit_point_ws, w_in_worldspace, distance, front_facing_shading_normal_ws, scene);
     }
 
-    let n_dot_l: f32 = dot(w_in_worldspace, front_facing_shading_normal_ws);
-    if (n_dot_l > 0.0 && visibility) {
-        let sample_intensity = LightSample::intensity(_self, hit_point_ws);
+    let wi_dot_n: f32 = dot(w_in_worldspace, front_facing_shading_normal_ws);
+    if (wi_dot_n > 0.0 && visibility) {
+        let sample_intensity = LightSample::intensity(_self, hit_point_ws) * _self.emission;
 
         var shading_pdf: f32;
         let reflectance: vec3<f32> = DisneyBsdf::evaluate(disney_bsdf, front_facing_shading_normal_ws,
             tangent_to_world, world_to_tangent, clearcoat_tangent_to_world, clearcoat_world_to_tangent,
             w_out_worldspace, w_in_worldspace, &shading_pdf);
-        let contribution: vec3<f32> = n_dot_l * reflectance;
 
-        return linear_to_luma(contribution * sample_intensity);
+        // 𝑝ˆ(𝑥) = 𝑓_𝑠(𝑥) 𝐺(𝑥) 𝑉(𝑥) 𝐿_𝑒(𝑥)
+        return linear_to_luma(reflectance * wi_dot_n * sample_intensity);
     }
 
     return 0.0;

--- a/crates/appearance-path-tracer-gpu/assets/shaders/shared/sky_bindings.wgsl
+++ b/crates/appearance-path-tracer-gpu/assets/shaders/shared/sky_bindings.wgsl
@@ -22,10 +22,18 @@ var sky_texture: texture_2d<f32>;
 @binding(2)
 var sky_texture_sampler: sampler;
 
-fn Sky::sun_intensity(zenith_angle_cos: f32) -> f32 {
-    var cutoff_angle: f32 = PI / 1.95;
+fn Sky::sun_intensity(direction: vec3<f32>) -> f32 {
+    const CUTOFF_ANGLE: f32 = PI / 1.95;
+
+    let l: vec3<f32> = -sky_constants.sun_direction;
+    let zenith_angle_cos: f32 = dot(l, UP);
     var intensity: f32 = sky_constants.sun_intensity *
-        max(0.0, 1.0 - exp(-((cutoff_angle - acos(zenith_angle_cos)) / 1.4)));
+        max(0.0, 1.0 - exp(-((CUTOFF_ANGLE - acos(zenith_angle_cos)) / 1.4)));
+
+    let cos_theta: f32 = dot(direction, l);
+    let sun_angular_diameter_cos: f32 = cos(sky_constants.sun_size * 0.1);
+    intensity *= select(0.0, 1.0, cos_theta > sun_angular_diameter_cos);
+
     return intensity;
 }
 
@@ -41,14 +49,9 @@ fn Sky::sky(direction: vec3<f32>, skip_sun: bool) -> vec3<f32> {
     var sky_color = textureSampleLevel(sky_texture, sky_texture_sampler, unit_vector_to_panorama_coords(direction), 0.0).rgb;
 
     if (!skip_sun) {
-        var l: vec3<f32> = -sky_constants.sun_direction;
-        var intensity = Sky::sun_intensity(dot(l, UP));
+        var intensity = Sky::sun_intensity(direction);
 
-        var cos_theta: f32 = dot(direction, l);
-        var sun_angular_diameter_cos: f32 = cos(sky_constants.sun_size * 0.1);
-        var sundisk: f32 = smoothstep(sun_angular_diameter_cos, sun_angular_diameter_cos + 0.4, cos_theta);
-
-        sky_color += intensity * 1000.0 * sundisk * sky_constants.sun_color;
+        sky_color += intensity * 1000.0 * sky_constants.sun_color;
     }
 
     return sky_color;

--- a/crates/appearance-path-tracer-gpu/assets/shaders/shared/sky_bindings.wgsl
+++ b/crates/appearance-path-tracer-gpu/assets/shaders/shared/sky_bindings.wgsl
@@ -1,6 +1,8 @@
 @include ::math
 @include appearance-path-tracer-gpu::shared/sampling
 
+const SUN_DISTANCE: f32 = 1e+6;
+
 struct SkyConstants {
     sun_direction: vec3<f32>,
     sun_size: f32,

--- a/crates/appearance-path-tracer-gpu/assets/shaders/shared/sky_bindings.wgsl
+++ b/crates/appearance-path-tracer-gpu/assets/shaders/shared/sky_bindings.wgsl
@@ -41,6 +41,26 @@ fn Sky::direction_to_sun(uv: vec2<f32>) -> vec3<f32> {
     return normalize(perturb_direction_vector(uv, -sky_constants.sun_direction, sky_constants.sun_size * 0.1));
 }
 
+fn Sky::inverse_direction_to_sun(direction: vec3<f32>) -> vec2<f32> {
+    let sun_dir: vec3<f32> = -sky_constants.sun_direction;
+    let bitangent: vec3<f32> = get_perpendicular_vector(sun_dir);
+    let tangent: vec3<f32> = cross(bitangent, sun_dir);
+
+    // Project direction onto basis vectors
+    let z: f32 = dot(direction, sun_dir);
+    let x: f32 = dot(direction, bitangent);
+    let y: f32 = dot(direction, tangent);
+
+    // Compute uv coordinates
+    let sin_t: f32 = sqrt(1.0 - z * z);
+    let phi: f32 = atan2(y, x);
+    
+    let uv_x: f32 = (phi / (2.0 * PI)) % 1.0; // Normalize phi to [0,1]
+    let uv_y: f32 = (z - cos(sky_constants.sun_size * 0.1)) / (1.0 - cos(sky_constants.sun_size * 0.1)); 
+
+    return vec2<f32>(uv_x, uv_y);
+}
+
 fn Sky::sun_solid_angle() -> f32 {
     return TWO_PI * (1.0 - cos(sky_constants.sun_size * 0.1));
 }

--- a/crates/appearance-path-tracer-gpu/assets/shaders/shared/vertex_pool.wgsl
+++ b/crates/appearance-path-tracer-gpu/assets/shaders/shared/vertex_pool.wgsl
@@ -11,19 +11,38 @@ struct VertexPoolSlice {
     _padding2: u32,
 };
 
-struct PackedVertex {
-    position: vec3<f32>,
-    normal: PackedNormalizedXyz10,
-    tex_coord: vec2<f32>,
-    tangent: PackedNormalizedXyz10,
-    tangent_handiness: f32,
-};
+struct EmissiveTriangleInstance { // EmissiveBlasInstance
+    transform: mat4x4<f32>, // TODO: put in separate buffer, also make 4x3
+    vertex_pool_slice_idx: u32,
+    num_triangles: u32,
+    cdf: f32,
+    _padding0: u32,
+}
+
+struct BlasInstance {
+    emissive_blas_instance_idx: u32,
+    vertex_pool_slice_index: u32,
+    _padding0: u32,
+    _padding1: u32,
+}
+
+fn BlasInstance::is_emissive(_self: BlasInstance) -> bool {
+    return _self.emissive_blas_instance_idx != U32_MAX;
+}
 
 struct Vertex {
     position: vec3<f32>,
     normal: vec3<f32>,
     tex_coord: vec2<f32>,
     tangent: vec4<f32>,
+};
+
+struct PackedVertex {
+    position: vec3<f32>,
+    normal: PackedNormalizedXyz10,
+    tex_coord: vec2<f32>,
+    tangent: PackedNormalizedXyz10,
+    tangent_handiness: f32,
 };
 
 fn PackedVertex::unpack(_self: PackedVertex) -> Vertex {

--- a/crates/appearance-path-tracer-gpu/assets/shaders/shared/vertex_pool_bindings.wgsl
+++ b/crates/appearance-path-tracer-gpu/assets/shaders/shared/vertex_pool_bindings.wgsl
@@ -1,4 +1,5 @@
 @include appearance-path-tracer-gpu::shared/vertex_pool
+@include appearance-path-tracer-gpu::shared/light_sample
 
 struct VertexPoolConstants {
     num_emissive_triangle_instances: u32,
@@ -8,7 +9,7 @@ struct VertexPoolConstants {
 }
 
 struct EmissiveTriangleInstance {
-    transform: mat4x4<f32>, // TODO: put in seperate buffer, also make 4x3
+    transform: mat4x4<f32>, // TODO: put in separate buffer, also make 4x3
     vertex_pool_slice_idx: u32,
     num_triangles: u32,
     cdf: f32,

--- a/crates/appearance-path-tracer-gpu/assets/shaders/shared/vertex_pool_bindings.wgsl
+++ b/crates/appearance-path-tracer-gpu/assets/shaders/shared/vertex_pool_bindings.wgsl
@@ -8,14 +8,6 @@ struct VertexPoolConstants {
     _padding2: u32,
 }
 
-struct EmissiveTriangleInstance {
-    transform: mat4x4<f32>, // TODO: put in separate buffer, also make 4x3
-    vertex_pool_slice_idx: u32,
-    num_triangles: u32,
-    cdf: f32,
-    _padding0: u32,
-}
-
 @group(1)
 @binding(0)
 var<uniform> vertex_pool_constants: VertexPoolConstants;
@@ -34,11 +26,15 @@ var<storage, read> triangle_material_indices: array<u32>;
 
 @group(1)
 @binding(4)
-var<storage, read> emissive_triangle_instances: array<EmissiveTriangleInstance>;
+var<storage, read> vertex_pool_slices: array<VertexPoolSlice>;
 
 @group(1)
 @binding(5)
-var<storage, read> vertex_pool_slices: array<VertexPoolSlice>;
+var<storage, read> emissive_triangle_instances: array<EmissiveTriangleInstance>;
+
+@group(1)
+@binding(6)
+var<storage, read> blas_instances: array<BlasInstance>;
 
 fn _calculate_bitangent(normal: vec3<f32>, tangent: vec4<f32>) -> vec3<f32> {
     var bitangent: vec3<f32> = cross(normal, tangent.xyz);

--- a/crates/appearance-path-tracer-gpu/assets/shaders/shared/vertex_pool_bindings.wgsl
+++ b/crates/appearance-path-tracer-gpu/assets/shaders/shared/vertex_pool_bindings.wgsl
@@ -8,7 +8,7 @@ struct VertexPoolConstants {
 }
 
 struct EmissiveTriangleInstance {
-    transform: mat4x4<f32>,
+    transform: mat4x4<f32>, // TODO: put in seperate buffer, also make 4x3
     vertex_pool_slice_idx: u32,
     num_triangles: u32,
     cdf: f32,

--- a/crates/appearance-path-tracer-gpu/assets/shaders/trace.wgsl
+++ b/crates/appearance-path-tracer-gpu/assets/shaders/trace.wgsl
@@ -103,8 +103,7 @@ fn main(@builtin(global_invocation_id) global_id: vec3<u32>,
         if (intersection.kind == RAY_QUERY_INTERSECTION_TRIANGLE) {
             depth_ws += intersection.t;
 
-            let blas_instance: BlasInstance = blas_instances[intersection.instance_custom_data];
-            let vertex_pool_slice: VertexPoolSlice = vertex_pool_slices[blas_instance.vertex_pool_slice_index];
+            let vertex_pool_slice: VertexPoolSlice = vertex_pool_slices[intersection.instance_custom_data];
 
             let barycentrics = vec3<f32>(1.0 - intersection.barycentrics.x - intersection.barycentrics.y, intersection.barycentrics);
 

--- a/crates/appearance-path-tracer-gpu/assets/shaders/trace.wgsl
+++ b/crates/appearance-path-tracer-gpu/assets/shaders/trace.wgsl
@@ -101,7 +101,7 @@ fn main(@builtin(global_invocation_id) global_id: vec3<u32>,
 
         let intersection = rayQueryGetCommittedIntersection(&rq);
         if (intersection.kind == RAY_QUERY_INTERSECTION_TRIANGLE) {
-            depth_ws += safely_traced_t(intersection.t);
+            depth_ws += intersection.t;
 
             let vertex_pool_slice_index: u32 = intersection.instance_custom_data;
             let vertex_pool_slice: VertexPoolSlice = vertex_pool_slices[vertex_pool_slice_index];
@@ -129,7 +129,7 @@ fn main(@builtin(global_invocation_id) global_id: vec3<u32>,
                     safe_origin_normal = normalize(cross(p01, p02));
 
                     // TODO: non-opaque geometry would be a better choice, not properly supported by wgpu yet
-                    origin += direction * safely_traced_t(intersection.t);
+                    origin += direction * intersection.t;
                     continue;
                 } else {
                     material_color.a = 1.0;
@@ -157,7 +157,7 @@ fn main(@builtin(global_invocation_id) global_id: vec3<u32>,
             let hit_tangent_ws: vec3<f32> = normalize((local_to_world_inv_trans * vec4<f32>(tbn[0], 1.0)).xyz);
             let hit_bitangent_ws: vec3<f32> = normalize((local_to_world_inv_trans * vec4<f32>(tbn[1], 1.0)).xyz);
             var hit_normal_ws: vec3<f32> = normalize((local_to_world_inv_trans * vec4<f32>(tbn[2], 1.0)).xyz);
-            let hit_point_ws = origin + direction * safely_traced_t(intersection.t);
+            let hit_point_ws = origin + direction * intersection.t;
 
             let hit_tangent_to_world = mat3x3<f32>(
                 hit_tangent_ws,
@@ -212,7 +212,7 @@ fn main(@builtin(global_invocation_id) global_id: vec3<u32>,
 
             let di_reservoir: DiReservoir = Nee::sample_ris(hit_point_ws, w_out_worldspace, front_facing_shading_normal_ws,
                 tangent_to_world, world_to_tangent, clearcoat_tangent_to_world, clearcoat_world_to_tangent,
-                disney_bsdf, safely_traced_t(intersection.t), back_face, &rng, scene);
+                disney_bsdf, intersection.t, back_face, &rng, scene);
             light_sample_reservoirs[id] = PackedDiReservoir::new(di_reservoir);
             light_sample_ctxs[id] = LightSampleCtx::new(tex_coord, material_idx, throughput, front_facing_shading_normal_ws, clearcoat_tangent_to_world[2]);
 
@@ -232,7 +232,7 @@ fn main(@builtin(global_invocation_id) global_id: vec3<u32>,
 
                 var gi_reservoir: GiReservoir = InlinePathTracer::sample_ris(hit_point_ws, w_out_worldspace, front_facing_shading_normal_ws,
                     tangent_to_world, world_to_tangent, clearcoat_tangent_to_world, clearcoat_world_to_tangent,
-                    disney_bsdf, throughput, safely_traced_t(intersection.t), back_face, &rng, scene);
+                    disney_bsdf, throughput, intersection.t, back_face, &rng, scene);
                 gi_reservoirs[id] = PackedGiReservoir::new(gi_reservoir);
             }
         } else {

--- a/crates/appearance-path-tracer-gpu/assets/shaders/trace.wgsl
+++ b/crates/appearance-path-tracer-gpu/assets/shaders/trace.wgsl
@@ -212,7 +212,7 @@ fn main(@builtin(global_invocation_id) global_id: vec3<u32>,
 
             let di_reservoir: DiReservoir = Nee::sample_ris(hit_point_ws, w_out_worldspace, front_facing_shading_normal_ws,
                 tangent_to_world, world_to_tangent, clearcoat_tangent_to_world, clearcoat_world_to_tangent,
-                disney_bsdf, &rng, scene);
+                disney_bsdf, safely_traced_t(intersection.t), back_face, &rng, scene);
             light_sample_reservoirs[id] = PackedDiReservoir::new(di_reservoir);
             light_sample_ctxs[id] = LightSampleCtx::new(tex_coord, material_idx, throughput, front_facing_shading_normal_ws, clearcoat_tangent_to_world[2]);
 

--- a/crates/appearance-path-tracer-gpu/assets/shaders/trace.wgsl
+++ b/crates/appearance-path-tracer-gpu/assets/shaders/trace.wgsl
@@ -103,8 +103,8 @@ fn main(@builtin(global_invocation_id) global_id: vec3<u32>,
         if (intersection.kind == RAY_QUERY_INTERSECTION_TRIANGLE) {
             depth_ws += intersection.t;
 
-            let vertex_pool_slice_index: u32 = intersection.instance_custom_data;
-            let vertex_pool_slice: VertexPoolSlice = vertex_pool_slices[vertex_pool_slice_index];
+            let blas_instance: BlasInstance = blas_instances[intersection.instance_custom_data];
+            let vertex_pool_slice: VertexPoolSlice = vertex_pool_slices[blas_instance.vertex_pool_slice_index];
 
             let barycentrics = vec3<f32>(1.0 - intersection.barycentrics.x - intersection.barycentrics.y, intersection.barycentrics);
 

--- a/crates/appearance-path-tracer-gpu/src/lib.rs
+++ b/crates/appearance-path-tracer-gpu/src/lib.rs
@@ -234,7 +234,7 @@ impl Default for PathTracerGpuConfig {
         Self {
             max_bounces: 1,
             sample_count: 1,
-            accum_frames: true,
+            accum_frames: false,
             restir_di: true,
             restir_gi: false,
             svgf: false,
@@ -414,7 +414,7 @@ impl PathTracerGpu {
                             &RestirDiPassParameters {
                                 resolution: self.local_resolution,
                                 seed,
-                                spatial_pass_count: 0,
+                                spatial_pass_count: 2,
                                 spatial_pixel_radius: 30.0,
                                 unbiased: true,
                                 rays: &self.sized_resources.rays,

--- a/crates/appearance-path-tracer-gpu/src/lib.rs
+++ b/crates/appearance-path-tracer-gpu/src/lib.rs
@@ -368,11 +368,15 @@ impl PathTracerGpu {
         );
 
         for sample in 0..self.config.sample_count {
+            //let seed = 1337 * self.config.sample_count + sample;
+            let seed = self.frame_idx * self.config.sample_count + sample;
+
             raygen_pass::encode(
                 &RaygenPassParameters {
                     inv_view,
                     inv_proj,
                     resolution: self.local_resolution,
+                    seed,
                     rays: &self.sized_resources.rays,
                 },
                 &ctx.device,
@@ -381,9 +385,6 @@ impl PathTracerGpu {
             );
 
             for i in 0..self.config.max_bounces {
-                //let seed = 1337 * self.config.sample_count + sample;
-                let seed = self.frame_idx * self.config.sample_count + sample;
-
                 trace_pass::encode(
                     &TracePassParameters {
                         ray_count: self.local_resolution.x * self.local_resolution.y,

--- a/crates/appearance-path-tracer-gpu/src/lib.rs
+++ b/crates/appearance-path-tracer-gpu/src/lib.rs
@@ -235,7 +235,7 @@ impl Default for PathTracerGpuConfig {
             max_bounces: 1,
             sample_count: 1,
             accum_frames: false,
-            restir_di: false,
+            restir_di: true,
             restir_gi: false,
             svgf: false,
             firefly_filter: false,

--- a/crates/appearance-path-tracer-gpu/src/lib.rs
+++ b/crates/appearance-path-tracer-gpu/src/lib.rs
@@ -235,7 +235,7 @@ impl Default for PathTracerGpuConfig {
             max_bounces: 1,
             sample_count: 1,
             accum_frames: false,
-            restir_di: true,
+            restir_di: false,
             restir_gi: false,
             svgf: false,
             firefly_filter: false,

--- a/crates/appearance-path-tracer-gpu/src/raygen_pass.rs
+++ b/crates/appearance-path-tracer-gpu/src/raygen_pass.rs
@@ -14,14 +14,15 @@ struct Constants {
     inv_proj: Mat4,
     width: u32,
     height: u32,
+    seed: u32,
     _padding0: u32,
-    _padding1: u32,
 }
 
 pub struct RaygenPassParameters<'a> {
     pub inv_view: Mat4,
     pub inv_proj: Mat4,
     pub resolution: UVec2,
+    pub seed: u32,
     pub rays: &'a wgpu::Buffer,
 }
 
@@ -83,8 +84,8 @@ pub fn encode(
             inv_proj: parameters.inv_proj,
             width: parameters.resolution.x,
             height: parameters.resolution.y,
+            seed: parameters.seed,
             _padding0: 0,
-            _padding1: 0,
         }),
         usage: wgpu::BufferUsages::UNIFORM,
     });

--- a/crates/appearance-path-tracer-gpu/src/restir_di_pass.rs
+++ b/crates/appearance-path-tracer-gpu/src/restir_di_pass.rs
@@ -35,12 +35,9 @@ struct SpatialConstants {
 
 #[repr(C)]
 pub struct PackedLightSample {
-    point: Vec3,
-    emission: u32,
-    triangle_area: f32,
-    triangle_normal: u32,
-    _padding0: u32,
-    _padding1: u32,
+    uv: Vec2,
+    emissive_triangle_instance_idx: u32,
+    local_triangle_idx: u32,
 }
 
 #[repr(C)]

--- a/crates/appearance-path-tracer-gpu/src/scene_resources/mod.rs
+++ b/crates/appearance-path-tracer-gpu/src/scene_resources/mod.rs
@@ -186,7 +186,7 @@ impl SceneResources {
             blas_instances.push(wgpu::TlasInstance::new(
                 blas,
                 transform4x3,
-                blas_instances.len() as u32,
+                vertex_slice_index,
                 0xff,
             ));
 

--- a/crates/appearance-path-tracer-gpu/src/scene_resources/mod.rs
+++ b/crates/appearance-path-tracer-gpu/src/scene_resources/mod.rs
@@ -278,12 +278,12 @@ impl SceneResources {
         self.vertex_pool.end_frame();
 
         // TODO: this kind of logic shouldn't be here, just for testing
-        self.sky.sun_info.direction = Vec3::new(
-            (self.frame_idx as f32 / 100.0).cos() * -0.2,
-            -1.0,
-            (self.frame_idx as f32 / 100.0).sin() * 0.3,
-        )
-        .normalize();
+        // self.sky.sun_info.direction = Vec3::new(
+        //     (self.frame_idx as f32 / 100.0).cos() * -0.2,
+        //     -1.0,
+        //     (self.frame_idx as f32 / 100.0).sin() * 0.3,
+        // )
+        // .normalize();
     }
 
     fn model_instance_iter_rec<F: FnMut(&VertexPoolAlloc, Mat4, Mat4)>(

--- a/crates/appearance-path-tracer-gpu/src/scene_resources/mod.rs
+++ b/crates/appearance-path-tracer-gpu/src/scene_resources/mod.rs
@@ -186,13 +186,15 @@ impl SceneResources {
             blas_instances.push(wgpu::TlasInstance::new(
                 blas,
                 transform4x3,
-                vertex_slice_index,
+                blas_instances.len() as u32,
                 0xff,
             ));
 
-            if model.is_emissive[*mesh_idx as usize] {
-                vertex_pool.submit_emissive_slice_instance(vertex_slice_index, transform);
-            }
+            vertex_pool.submit_slice_instance(
+                vertex_slice_index,
+                transform,
+                model.is_emissive[*mesh_idx as usize],
+            );
 
             blas_idx += 1;
         }

--- a/crates/appearance-path-tracer-gpu/src/scene_resources/mod.rs
+++ b/crates/appearance-path-tracer-gpu/src/scene_resources/mod.rs
@@ -5,7 +5,7 @@ use appearance_model::Model;
 use appearance_texture::Texture;
 use appearance_wgpu::wgpu::{self, TlasPackage};
 use appearance_world::visible_world_action::VisibleWorldActionType;
-use glam::Mat4;
+use glam::{Mat4, Vec3};
 use material_pool::MaterialPool;
 use scene_model::SceneModel;
 use sky::Sky;
@@ -280,12 +280,12 @@ impl SceneResources {
         self.vertex_pool.end_frame();
 
         // TODO: this kind of logic shouldn't be here, just for testing
-        // self.sky.sun_info.direction = Vec3::new(
-        //     (self.frame_idx as f32 / 100.0).cos() * -0.2,
-        //     -1.0,
-        //     (self.frame_idx as f32 / 100.0).sin() * 0.3,
-        // )
-        // .normalize();
+        self.sky.sun_info.direction = Vec3::new(
+            (self.frame_idx as f32 / 100.0).cos() * -0.2,
+            -1.0,
+            (self.frame_idx as f32 / 100.0).sin() * 0.3,
+        )
+        .normalize();
     }
 
     fn model_instance_iter_rec<F: FnMut(&VertexPoolAlloc, Mat4, Mat4)>(

--- a/crates/appearance-path-tracer-gpu/src/scene_resources/mod.rs
+++ b/crates/appearance-path-tracer-gpu/src/scene_resources/mod.rs
@@ -5,7 +5,7 @@ use appearance_model::Model;
 use appearance_texture::Texture;
 use appearance_wgpu::wgpu::{self, TlasPackage};
 use appearance_world::visible_world_action::VisibleWorldActionType;
-use glam::{Mat4, Vec3};
+use glam::Mat4;
 use material_pool::MaterialPool;
 use scene_model::SceneModel;
 use sky::Sky;

--- a/crates/appearance-transform/src/lib.rs
+++ b/crates/appearance-transform/src/lib.rs
@@ -170,7 +170,7 @@ impl Transform {
         let mut matrix = self.matrix.lock().unwrap();
 
         if matrix.1 {
-            matrix.0 = Mat4::look_to_rh(self.translation, self.forward(), UP);
+            matrix.0 = Mat4::look_to_rh(self.translation, self.forward(), self.up());
             matrix.1 = false;
             self.has_changed_this_frame.store(true, Ordering::Relaxed);
         }


### PR DESCRIPTION
This PR allows better tracking of moving lights for temporal integration (mostly restir). This is done by having the `LightSample` struct point to a triangle index with associated barycentric coords, instead of the previous pre-evaluated point on the triangle and presample emission. This would become invalid when the light where to move or change in emission intensity.